### PR TITLE
Updates on tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         qgis_version_tag:
-          - latest
           - release-3_16
           - release-3_18
           - release-3_20


### PR DESCRIPTION
Removed testing on QGIS latest docker images, as they are not available at the moment.