### PR TITLE
Save and retrieve connections to/from the plugin settings

### DIFF
--- a/src/qgis_stac/conf.py
+++ b/src/qgis_stac/conf.py
@@ -164,7 +164,6 @@ class SettingsManager(QtCore.QObject):
                             connection_id, connection_settings
                         )
                     )
-        result.sort(key=lambda obj: obj.name)
         return result
 
     def delete_all_connections(self):

--- a/src/qgis_stac/conf.py
+++ b/src/qgis_stac/conf.py
@@ -5,7 +5,6 @@
 
 import contextlib
 import dataclasses
-import logging
 import typing
 import uuid
 
@@ -14,7 +13,6 @@ from qgis.PyQt import (
     QtWidgets,
 )
 from qgis.core import QgsRectangle, QgsSettings
-logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
@@ -85,6 +83,8 @@ class SettingsManager(QtCore.QObject):
     SELECTED_CONNECTION_KEY: str = "selected_connection"
 
     settings = QgsSettings()
+
+    connections_settings_updated = QtCore.pyqtSignal(str)
 
     def set_value(self, name: str, value):
         """Adds a new setting key and value on the plugin specific settings.
@@ -176,6 +176,7 @@ class SettingsManager(QtCore.QObject):
             for connection_name in settings.childGroups():
                 settings.remove(connection_name)
         self.clear_current_connection()
+        self.connections_settings_updated.emit("")
 
     def find_connection_by_name(self, name):
         """Finds a connection setting inside the plugin QgsSettings by name.
@@ -242,6 +243,7 @@ class SettingsManager(QtCore.QObject):
             settings.setValue("url", connection_settings.url)
             settings.setValue("page_size", connection_settings.page_size)
             settings.setValue("auth_config", connection_settings.auth_config)
+        self.connections_settings_updated.emit("")
 
     def delete_connection(self, identifier: uuid.UUID):
         """Deletes plugin connection that match the passed identifier.
@@ -256,6 +258,7 @@ class SettingsManager(QtCore.QObject):
                 f"{self.CONNECTION_GROUP_NAME}")\
                 as settings:
             settings.remove(str(identifier))
+        self.connections_settings_updated.emit("")
 
     def get_current_connection(self) -> typing.Optional[ConnectionSettings]:
         """Gets the current active connection from the QgsSettings.
@@ -284,12 +287,14 @@ class SettingsManager(QtCore.QObject):
         serialized_id = str(identifier)
         with qgis_settings(self.BASE_GROUP_NAME) as settings:
             settings.setValue(self.SELECTED_CONNECTION_KEY, serialized_id)
+        self.connections_settings_updated.emit("")
 
     def clear_current_connection(self):
         """Removes the current selected connection in the settings.
         """
         with qgis_settings(self.BASE_GROUP_NAME) as settings:
             settings.setValue(self.SELECTED_CONNECTION_KEY, None)
+        self.connections_settings_updated.emit("")
 
     def is_current_connection(self, identifier: uuid.UUID):
         """Checks if the connection with the passed identifier

--- a/src/qgis_stac/gui/connection_dialog.py
+++ b/src/qgis_stac/gui/connection_dialog.py
@@ -15,9 +15,9 @@ DialogUi, _ = loadUiType(
 
 
 class ConnectionDialog(QtWidgets.QDialog, DialogUi):
+    """ Dialog for adding, editing plugin connections"""
 
-    def __init__(self,
-                 connection_settings: typing.Optional[ConnectionSettings] = None
+    def __init__(self
                  ):
         super().__init__()
         self.setupUi(self)
@@ -31,6 +31,11 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
             signal.connect(self.update_ok_buttons)
 
     def load_connection_settings(self, connection_settings: ConnectionSettings):
+        """ Sets this dialog inputs values as defined in the passed connection settings.
+
+        :param connection_settings: Connection settings corresponding with the dialog.
+        :type connection_settings: ConnectionSettings
+        """
         self.name_edit.setText(connection_settings.name)
         self.url_edit.setText(connection_settings.base_url)
         self.auth_config.setConfigId(connection_settings.auth_config)
@@ -57,6 +62,9 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         super().accept()
 
     def update_ok_buttons(self):
+        """ Changes state of the connection dialog OK button
+        due to the avaialable values on the name and url inputs.
+        """
         enabled_state = self.name_edit.text() != "" and \
                         self.url_edit.text() != ""
         self.buttonBox.button(

--- a/src/qgis_stac/gui/connection_dialog.py
+++ b/src/qgis_stac/gui/connection_dialog.py
@@ -1,7 +1,13 @@
 import os
+import re
+import uuid
+import typing
 from qgis.PyQt import QtWidgets
 from qgis.PyQt.uic import loadUiType
-
+from ..conf import (
+    ConnectionSettings,
+    settings_manager
+)
 
 DialogUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/connection_dialog.ui")
@@ -9,11 +15,12 @@ DialogUi, _ = loadUiType(
 
 
 class ConnectionDialog(QtWidgets.QDialog, DialogUi):
-    def __init__(
-            self,
-            parent=None,
-    ):
-        super().__init__(parent)
+    connection_id: uuid.UUID
+
+    def __init__(self,
+                 connection_settings: typing.Optional[ConnectionSettings] = None
+                 ):
+        super().__init__()
         self.setupUi(self)
         self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(False)
 
@@ -23,6 +30,46 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         ]
         for signal in ok_signals:
             signal.connect(self.update_ok_buttons)
+        if connection_settings is not None:
+            self.connection_id = connection_settings.id
+            self.load_connection_settings(connection_settings)
+        else:
+            self.connection_id = uuid.uuid4()
+
+    def load_connection_settings(self, connection_settings: ConnectionSettings):
+        self.name_edit.setText(connection_settings.name)
+        self.url_edit.setText(connection_settings.base_url)
+        self.auth_config.setConfigId(connection_settings.auth_config)
+        self.page_size.setValue(connection_settings.page_size)
+
+    def get_connection_settings(self) -> ConnectionSettings:
+
+        return ConnectionSettings(
+            id=self.connection_id,
+            name=self.name_edit.text().strip(),
+            url=self.url_edit.text().strip(),
+            page_size=self.page_size.value(),
+            auth_config=self.auth_config.configId(),
+        )
+
+    def accept(self):
+        connection_settings = self.get_connection_settings()
+        name_pattern = re.compile(
+            f"^{connection_settings.name}$|^{connection_settings.name}(\(\d+\))$"
+        )
+        duplicate_names = []
+        for connection_conf in settings_manager.list_connections():
+            if connection_conf.id == connection_settings.id:
+                continue  # we don't want to compare against ourselves
+            if name_pattern.search(connection_conf.name) is not None:
+                duplicate_names.append(connection_conf.name)
+        if len(duplicate_names) > 0:
+            connection_settings.name = (
+                f"{connection_settings.name}({len(duplicate_names)})"
+            )
+        settings_manager.save_connection_settings(connection_settings)
+        settings_manager.set_current_connection(connection_settings.id)
+        super().accept()
 
     def update_ok_buttons(self):
         enabled_state = self.name_edit.text() != "" and self.url_edit.text() != ""

--- a/src/qgis_stac/gui/connection_dialog.py
+++ b/src/qgis_stac/gui/connection_dialog.py
@@ -15,7 +15,7 @@ DialogUi, _ = loadUiType(
 
 
 class ConnectionDialog(QtWidgets.QDialog, DialogUi):
-    """ Dialog for adding, editing plugin connections"""
+    """ Dialog for adding and editing plugin connections details"""
 
     def __init__(self
                  ):
@@ -42,6 +42,7 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         self.page_size.setValue(connection_settings.page_size)
 
     def accept(self):
+        """ Handles logic for adding new connections"""
         connection_settings = ConnectionSettings(
             id=uuid.uuid4(),
             name=self.name_edit.text().strip(),
@@ -62,8 +63,8 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         super().accept()
 
     def update_ok_buttons(self):
-        """ Changes state of the connection dialog OK button
-        due to the avaialable values on the name and url inputs.
+        """ Responsible for changing the state of the
+         connection dialog OK button.
         """
         enabled_state = self.name_edit.text() != "" and \
                         self.url_edit.text() != ""

--- a/src/qgis_stac/gui/connection_dialog.py
+++ b/src/qgis_stac/gui/connection_dialog.py
@@ -45,14 +45,19 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
             auth_config=self.auth_config.configId(),
         )
         existing_connection_names = []
-        if connection_settings.name in (connexion.name for connexion in settings_manager.list_connections()):
+        if connection_settings.name in (
+                connection.name for connection in
+                settings_manager.list_connections()):
             existing_connection_names.append(connection_settings.name)
         if len(existing_connection_names) > 0:
-            connection_settings.name = f"{connection_settings.name}_{len(existing_connection_names)}"
+            connection_settings.name = f"{connection_settings.name}" \
+                                       f"_{len(existing_connection_names)}"
         settings_manager.save_connection_settings(connection_settings)
         settings_manager.set_current_connection(connection_settings.id)
         super().accept()
 
     def update_ok_buttons(self):
-        enabled_state = self.name_edit.text() != "" and self.url_edit.text() != ""
-        self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(enabled_state)
+        enabled_state = self.name_edit.text() != "" and \
+                        self.url_edit.text() != ""
+        self.buttonBox.button(
+            QtWidgets.QDialogButtonBox.Ok).setEnabled(enabled_state)

--- a/src/qgis_stac/gui/main.py
+++ b/src/qgis_stac/gui/main.py
@@ -17,7 +17,7 @@ WidgetUi, _ = loadUiType(
 
 
 class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
-
+    """ Main plugin widget that has tabs for search, results and settings."""
     def __init__(
             self,
             parent=None,
@@ -25,12 +25,12 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         super().__init__(parent)
         self.setupUi(self)
         self.new_connection_btn.clicked.connect(self.add_connection)
-        self.connections_cmb.currentIndexChanged.connect(
-            self.toggle_connection_management_buttons
+        self.connections_box.currentIndexChanged.connect(
+            self.update_connection_buttons
         )
         self.update_connections_combobox()
-        self.toggle_connection_management_buttons()
-        self.connections_cmb.activated.connect(self.update_current_connection)
+        self.update_connection_buttons()
+        self.connections_box.activated.connect(self.update_current_connection)
         self.pagination.setVisible(False)
 
         self.search_btn.clicked.connect(
@@ -42,9 +42,20 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.update_current_connection(self.connections_cmb.currentIndex())
 
     def add_connection(self):
+        """ Adds a new connection into the plugin, then updates
+        the connections combo box list to show the added connection.
+        """
         connection_dialog = ConnectionDialog()
         connection_dialog.exec_()
         self.update_connections_combobox()
+
+    def update_connection_buttons(self):
+        """ Updates the edit and delete connection buttons state
+        """
+        current_name = self.connections_cmb.currentText()
+        enabled = current_name != ""
+        self.edit_connection_btn.setEnabled(enabled)
+        self.delete_connection_btn.setEnabled(enabled)
 
     def update_current_connection(self, current_index: int):
         current_text = self.connections_cmb.itemText(current_index)
@@ -79,13 +90,10 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
     def display_search_error(self):
         raise NotImplementedError
 
-    def toggle_connection_management_buttons(self):
-        current_name = self.connections_cmb.currentText()
-        enabled = current_name != ""
-        self.edit_connection_btn.setEnabled(enabled)
-        self.delete_connection_btn.setEnabled(enabled)
-
     def update_connections_combobox(self):
+        """ Updates connections list displayed on the connection
+        combox box to contain latest list of the connections.
+        """
         existing_connections = settings_manager.list_connections()
         self.connections_cmb.clear()
         if len(existing_connections) > 0:
@@ -98,6 +106,13 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
                 self.connections_cmb.setCurrentIndex(0)
 
     def update_current_connection(self, current_index: int):
+        """ Sets the select connection from the connection combo box as the
+        current selected connection.
+
+        :param current_index: Index of the selected item from the connection combo
+        box
+        :type current_index: int
+        """
         current_text = self.connections_cmb.itemText(current_index)
         if current_text != "":
             current_connection = settings_manager.\

--- a/src/qgis_stac/gui/main.py
+++ b/src/qgis_stac/gui/main.py
@@ -17,11 +17,6 @@ WidgetUi, _ = loadUiType(
 
 
 class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
-    new_connection_btn: QtWidgets.QPushButton
-    pagination: QtWidgets.QWidget
-    connections_cmb: QtWidgets.QComboBox
-    edit_connection_btn: QtWidgets.QPushButton
-    delete_connection_btn: QtWidgets.QPushButton
 
     def __init__(
             self,
@@ -101,3 +96,13 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
                 self.connections_cmb.setCurrentIndex(current_index)
             else:
                 self.connections_cmb.setCurrentIndex(0)
+
+    def update_current_connection(self, current_index: int):
+        current_text = self.connections_cmb.itemText(current_index)
+        if current_text != "":
+            current_connection = settings_manager.\
+                find_connection_by_name(current_text)
+            settings_manager.set_current_connection(
+                current_connection.id
+            )
+

--- a/src/qgis_stac/ui/connection_dialog.ui
+++ b/src/qgis_stac/ui/connection_dialog.ui
@@ -21,7 +21,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="7" column="0" colspan="2">
-       <widget class="QPushButton" name="pushButton">
+       <widget class="QPushButton" name="test_btn">
         <property name="text">
          <string>Test connection</string>
         </property>
@@ -38,7 +38,7 @@
        </widget>
       </item>
       <item row="2" column="0" colspan="2">
-       <widget class="QgsAuthConfigSelect" name="mAuthConfigSelect">
+       <widget class="QgsAuthConfigSelect" name="auth_config">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
           <horstretch>0</horstretch>
@@ -61,7 +61,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QgsSpinBox" name="mQgsSpinBox"/>
+          <widget class="QgsSpinBox" name="page_size"/>
          </item>
         </layout>
        </widget>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>831</width>
-    <height>713</height>
+    <width>891</width>
+    <height>734</height>
    </rect>
   </property>
   <property name="font">
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -17,7 +17,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>STAC Search</string>
+   <string>STAC API Browser</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">
@@ -145,6 +145,12 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout">
+          <item row="2" column="1">
+           <widget class="QDateTimeEdit" name="dateTimeEdit_2"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QDateTimeEdit" name="dateTimeEdit"/>
+          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_13">
             <property name="text">
@@ -152,18 +158,12 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QgsDateTimeEdit" name="start_dte"/>
-          </item>
           <item row="1" column="1">
            <widget class="QLabel" name="label_14">
             <property name="text">
              <string>End</string>
             </property>
            </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsDateTimeEdit" name="end_dte"/>
           </item>
          </layout>
         </widget>
@@ -336,9 +336,9 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="ResultsBrowser">
+     <widget class="QWidget" name="Results">
       <attribute name="title">
-       <string>Results Browser</string>
+       <string>Results</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8">
        <item>
@@ -577,11 +577,6 @@
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDateTimeEdit</class>
-   <extends>QDateTimeEdit</extends>
-   <header>qgsdatetimeedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsExtentGroupBox</class>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -49,7 +49,7 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="QComboBox" name="connections_cmb"/>
+           <widget class="QComboBox" name="connections_box"/>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
Supersedes https://github.com/stac-utils/qgis-stac-plugin/pull/25

Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/16 and https://github.com/stac-utils/qgis-stac-plugin/issues/18

Adds functionality to enable adding new connections and store them in the plugin connection settings.

Screenshot showing how connections can be added
![connections_adding](https://user-images.githubusercontent.com/2663775/144222970-5a38ccad-efc4-4273-86cf-d288a5cf5ea9.gif)

