### PR TITLE
Implemented edit and remove functions for connections

### DIFF
--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -77,7 +77,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="delete_connection_btn">
+             <widget class="QPushButton" name="remove_connection_btn">
               <property name="enabled">
                <bool>false</bool>
               </property>

--- a/src/qgis_stac/utils.py
+++ b/src/qgis_stac/utils.py
@@ -3,13 +3,29 @@
     Plugin utilities
 """
 import uuid
+import datetime
 
+from qgis.PyQt import QtCore
 from .conf import (
     ConnectionSettings,
     settings_manager
 )
 
 from .definitions.catalog import CATALOGS
+
+
+def tr(message):
+    """Get the translation for a string using Qt translation API.
+    We implement this ourselves since we do not inherit QObject.
+
+    :param message: String for translation.
+    :type message: str, QString
+
+    :returns: Translated version of message.
+    :rtype: QString
+    """
+    # noinspection PyTypeChecker,PyArgumentList,PyCallByClass
+    return QtCore.QCoreApplication.translate("QgisStac", message)
 
 
 def config_defaults_catalogs():
@@ -27,6 +43,7 @@ def config_defaults_catalogs():
                 name=catalog['name'],
                 url=catalog['url'],
                 page_size=5,
+                created_date=datetime.datetime.now(),
                 auth_config=None,
             )
             settings_manager.save_connection_settings(connection_settings)


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/30

Adds functionality to handle connections edit and removal. Now edits on connection name will update the same connection and any new connection with a name that matches some available connection then the new connection name will be tagged with a no suffix; eg "name" will be "name(1)"

When removing a connection we are setting the most recent added connection as the current connection on the connections combo box.

screenshot showing the edit and remove buttons in action
![edit_remove_functionality](https://user-images.githubusercontent.com/2663775/144323120-9441651a-9b98-4290-b98f-0c209c73e11b.gif)


