### PR TITLE
Implement search

### DIFF
--- a/src/qgis_stac/api/base.py
+++ b/src/qgis_stac/api/base.py
@@ -109,7 +109,7 @@ class BaseClient(QtCore.QObject):
 
     def get_pagination(self, item_collection):
         pagination = ResourcePagination()
-        for link in item_collection['links']:
+        for link in item_collection.to_dict()['links']:
             if link['rel'] == "next":
                 pagination.next_page = link['href']
             elif link['rel'] == "previous":

--- a/src/qgis_stac/api/base.py
+++ b/src/qgis_stac/api/base.py
@@ -107,6 +107,16 @@ class BaseClient(QtCore.QObject):
 
         QgsApplication.taskManager().addTask(self.content_task)
 
+    def get_pagination(self, item_collection):
+        pagination = ResourcePagination()
+        for link in item_collection['links']:
+            if link['rel'] == "next":
+                pagination.next_page = link['href']
+            elif link['rel'] == "previous":
+                pagination.previous_page = link['href']
+
+        return pagination
+
     def handle_collections(
             self,
             collections

--- a/src/qgis_stac/api/base.py
+++ b/src/qgis_stac/api/base.py
@@ -108,6 +108,14 @@ class BaseClient(QtCore.QObject):
         QgsApplication.taskManager().addTask(self.content_task)
 
     def get_pagination(self, item_collection):
+        """ Generates pagination details from the pystac_client item collection
+
+        :param item_collection: Collection of items generator
+        :type item_collection: ItemCollection
+
+        :returns: Pagination instance
+        :rtype: ResourcePagination
+         """
         pagination = ResourcePagination()
         for link in item_collection.to_dict()['links']:
             if link['rel'] == "next":

--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -26,14 +26,18 @@ class Client(BaseClient):
         """
         items = []
         pagination = ResourcePagination()
+        properties = None
         for item in items_response.get_items():
-            item_datetime = datetime.datetime.strptime(
-                item.properties.get("datetime"),
-                "%Y-%m-%dT%H:%M:%SZ"
-            )
-            properties = ResourceProperties(
-                resource_datetime=item_datetime
-            )
+            try:
+                item_datetime = datetime.datetime.strptime(
+                    item.properties.get("datetime"),
+                    "%Y-%m-%dT%H:%M:%SZ"
+                )
+                properties = ResourceProperties(
+                    resource_datetime=item_datetime
+                )
+            except:
+                pass
             assets = []
             for key, asset in item.assets.items():
                 item_asset = ResourceAsset(
@@ -41,7 +45,7 @@ class Client(BaseClient):
                     title=asset.title,
                     description=asset.description,
                     type=asset.media_type,
-                    roles=asset.roles
+                    roles=asset.roles or []
                 )
                 assets.append(item_asset)
             item_result = Item(

--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -9,6 +9,8 @@ from .models import (
     ResourceProperties,
 )
 
+from ..utils import log
+
 
 class Client(BaseClient):
     """ API client class that provides implementation of the
@@ -36,7 +38,8 @@ class Client(BaseClient):
                 properties = ResourceProperties(
                     resource_datetime=item_datetime
                 )
-            except:
+            except (TypeError, ValueError) as e:
+                log(f"Error in passing item properties datetime, {str(e)}")
                 pass
             assets = []
             for key, asset in item.assets.items():

--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -1,6 +1,13 @@
+import datetime
 
 from .base import BaseClient
-from .models import Collection, Item, ResourcePagination
+from .models import (
+    Collection,
+    Item,
+    ResourceAsset,
+    ResourcePagination,
+    ResourceProperties,
+)
 
 
 class Client(BaseClient):
@@ -20,8 +27,29 @@ class Client(BaseClient):
         items = []
         pagination = ResourcePagination()
         for item in items_response.get_items():
+            item_datetime = datetime.datetime.strptime(
+                item.properties.get("datetime"),
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            properties = ResourceProperties(
+                resource_datetime=item_datetime
+            )
+            assets = []
+            for key, asset in item.assets.items():
+                item_asset = ResourceAsset(
+                    href=asset.href,
+                    title=asset.title,
+                    description=asset.description,
+                    type=asset.media_type,
+                    roles=asset.roles
+                )
+                assets.append(item_asset)
             item_result = Item(
-                id=item.id
+                id=item.id,
+                properties=properties,
+                collection=item.collection_id,
+                assets=assets
+
             )
             items.append(item_result)
 

--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -18,13 +18,12 @@ class Client(BaseClient):
         :type items_response: List[models.Items]
         """
         items = []
-        pagination = self.get_pagination(items_response.get_item_collections()[0])
-        for item_collection in items_response.get_item_collections():
-            for item in item_collection:
-                item_result = Item(
-                    id=item.id
-                )
-                items.append(item_result)
+        pagination = ResourcePagination()
+        for item in items_response.get_items():
+            item_result = Item(
+                id=item.id
+            )
+            items.append(item_result)
 
         self.items_received.emit(items, pagination)
 

--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -18,15 +18,13 @@ class Client(BaseClient):
         :type items_response: List[models.Items]
         """
         items = []
-        for item in items_response.get_items():
-            item_result = Item(
-                id=item.id
-            )
-            items.append(item_result)
-
-        # TODO query filter pagination results from the
-        # response
-        pagination = ResourcePagination()
+        pagination = self.get_pagination(items_response.get_item_collections()[0])
+        for item_collection in items_response.get_item_collections():
+            for item in item_collection:
+                item_result = Item(
+                    id=item.id
+                )
+                items.append(item_result)
 
         self.items_received.emit(items, pagination)
 

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -207,7 +207,7 @@ class ItemSearch:
         parameters = {
             "ids": self.ids,
             "collections": self.collections or None,
-            "limit": self.page_size,
+            "max_items": self.page_size,
             "bbox": bbox,
             "datetime": datetime_str,
         }

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -200,13 +200,15 @@ class ItemSearch:
         :returns: Dictionary of parameters
         :rtype: dict
         """
-
+        spatial_extent_available = (self.spatial_extent and
+                                    not self.spatial_extent.isNull()
+                                    )
         bbox = [
             self.spatial_extent.xMinimum(),
             self.spatial_extent.yMinimum(),
             self.spatial_extent.xMaximum(),
             self.spatial_extent.yMaximum(),
-        ] if self.spatial_extent else None
+        ] if spatial_extent_available else None
 
         datetime_str = None
         if self.start_datetime and not self.end_datetime:
@@ -215,7 +217,7 @@ class ItemSearch:
             datetime_str = f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
         elif self.start_datetime and self.end_datetime:
             datetime_str = f"{self.start_datetime.toString(QtCore.Qt.ISODate)}/" \
-                       f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
+                           f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
 
         parameters = {
             "ids": self.ids,

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -30,13 +30,19 @@ class ResourcePagination:
     previous_page: str = None
 
 
-class LAYER_TYPES(enum.Enum):
-    PNG = ''
-    COLLECTION = 'collection'
-    DATE = 'date'
+class AssetRoles(enum.Enum):
+    """ STAC Item assets roles defined as outlined in
+    https://github.com/radiantearth/stac-api-spec/blob/
+    master/stac-spec/item-spec/item-spec.md#asset-roles
+    """
+    THUMBNAIL = 'thumbnail'
+    OVERVIEW = 'overview'
+    DATA = 'data'
+    METADATA = 'metadata'
 
 
 class SortField(enum.Enum):
+    """ Holds the field value used when sorting items results."""
     ID = 'name'
     COLLECTION = 'collection'
     DATE = 'date'

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -133,20 +133,20 @@ class Catalog:
 @dataclasses.dataclass
 class Collection:
     """ Represents the STAC API Collection"""
-    id: int
-    uuid: UUID
-    title: str
-    description: str
-    keywords: typing.List[str]
-    license: str
-    type: ResourceType
-    stac_version: str
-    stac_extensions: typing.List[str]
-    links: typing.List[ResourceLink]
-    assets: typing.Dict[str, ResourceAsset]
-    providers: typing.List[ResourceProvider]
-    extent: ResourceExtent
-    summaries: typing.Dict[str, str]
+    id: int = None
+    uuid: UUID = None
+    title: str = None
+    description: str = None
+    keywords: typing.List[str] = None
+    license: str = None
+    type: ResourceType = None
+    stac_version: str = None
+    stac_extensions: typing.List[str] = None
+    links: typing.List[ResourceLink] = None
+    assets: typing.Dict[str, ResourceAsset] = None
+    providers: typing.List[ResourceProvider] = None
+    extent: ResourceExtent = None
+    summaries: typing.Dict[str, str] = None
 
 
 @dataclasses.dataclass
@@ -199,13 +199,13 @@ class ItemSearch:
         elif self.end_datetime and not self.start_datetime:
             datetime_str = f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
         elif self.start_datetime and self.end_datetime:
-            datetime_str = f"{self.start_datetime.toString(QtCore.Qt.ISODate)}\"" \
+            datetime_str = f"{self.start_datetime.toString(QtCore.Qt.ISODate)}/" \
                        f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
 
         parameters = {
             "ids": self.ids,
             "collections": self.collections or None,
-            "limit": self.page_size or None,
+            "page": self.page,
             "bbox": bbox,
             "datetime": datetime_str,
         }

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -30,6 +30,12 @@ class ResourcePagination:
     previous_page: str = None
 
 
+class SortField(enum.Enum):
+    ID = 'name'
+    COLLECTION = 'collection'
+    DATE = 'date'
+
+
 class GeometryType(enum.Enum):
     """Enum to represent the available geometry types """
 

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -26,6 +26,8 @@ class ResourcePagination:
     total_records: int = 0
     current_page: int = 1
     page_size: int = 10
+    next_page: str = None
+    previous_page: str = None
 
 
 class GeometryType(enum.Enum):
@@ -205,7 +207,7 @@ class ItemSearch:
         parameters = {
             "ids": self.ids,
             "collections": self.collections or None,
-            "page": self.page,
+            "limit": self.page_size,
             "bbox": bbox,
             "datetime": datetime_str,
         }

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -30,6 +30,12 @@ class ResourcePagination:
     previous_page: str = None
 
 
+class LAYER_TYPES(enum.Enum):
+    PNG = ''
+    COLLECTION = 'collection'
+    DATE = 'date'
+
+
 class SortField(enum.Enum):
     ID = 'name'
     COLLECTION = 'collection'
@@ -90,21 +96,23 @@ class ResourceLink:
     type: str
 
 
+@dataclasses.dataclass
 class ResourceProperties:
     """Represents the STAC API Properties object,
     which contains additional metadata fields
     for the STAC API resources.
     """
-    title: str
-    description: str
-    datetime: datetime.datetime
-    created: datetime.datetime
-    updated: datetime.datetime
-    start_datetime: datetime.datetime
-    end_datetime: datetime.datetime
-    license: str
+    title: str = None
+    description: str = None
+    resource_datetime: datetime.datetime = None
+    created: datetime.datetime = None
+    updated: datetime.datetime = None
+    start_datetime: datetime.datetime = None
+    end_datetime: datetime.datetime = None
+    license: str = None
 
 
+@dataclasses.dataclass
 class ResourceProvider:
     """Represents the STAC API Provider object,
     which contains information about the provider that
@@ -122,7 +130,6 @@ class ResourceGeometry:
     """The GeoJSON geometry footprint STAC API assets"""
     type: GeometryType
     coordinates: typing.List[typing.List[int]]
-
 
 
 @dataclasses.dataclass
@@ -160,7 +167,7 @@ class Collection:
 @dataclasses.dataclass
 class Item:
     """ Represents the STAC API Item"""
-    id: int
+    id: str
     uuid: UUID = None
     type: ResourceType = None
     stac_version: str = None

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -64,7 +64,7 @@ class ContentFetcherTask(QgsTask):
         """
         self.client = Client.open(self.url)
         try:
-            if self.resource_type ==\
+            if self.resource_type == \
                     ResourceType.FEATURE:
                 self.response = self.client.search(
                     **self.search_params.params()

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -17,8 +17,10 @@ from .models import (
     ResourceType,
 )
 
-from ..lib.pystac_client import Client
-from ..lib.pystac_client.exceptions import APIError
+from pystac_client import Client
+from pystac_client.exceptions import APIError
+
+from ..utils import log
 
 
 class ContentFetcherTask(QgsTask):
@@ -73,6 +75,7 @@ class ContentFetcherTask(QgsTask):
             else:
                 raise NotImplementedError
         except APIError as err:
+            log(str(err))
             self.error = str(err)
 
         return self.response is not None

--- a/src/qgis_stac/definitions/catalog.py
+++ b/src/qgis_stac/definitions/catalog.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+"""
+    Definitions for all pre-installed STAC API catalog connections
+"""
+
 CATALOGS = [
     {
         "id": "07e3e9dd-cbad-4cf6-8336-424b88abf8f3",

--- a/src/qgis_stac/gui/connection_dialog.py
+++ b/src/qgis_stac/gui/connection_dialog.py
@@ -70,7 +70,9 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         existing_connection_names = []
         if connection_settings.name in (
                 connection.name for connection in
-                settings_manager.list_connections()):
+                settings_manager.list_connections()
+                if connection.id != connection_settings.id
+        ):
             existing_connection_names.append(connection_settings.name)
         if len(existing_connection_names) > 0:
             connection_settings.name = f"{connection_settings.name}" \

--- a/src/qgis_stac/gui/main.py
+++ b/src/qgis_stac/gui/main.py
@@ -196,6 +196,13 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             else:
                 self.connections_box.setCurrentIndex(0)
 
+    def previous_items(self):
+        self.page -= 1
+        self.search_api()
+
+    def next_items(self):
+        self.page += 1
+        self.search_api()
 
     def search_api(self):
         """ Uses the filters available on the search tab to
@@ -216,7 +223,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             ItemSearch(
                 collections=collections,
                 page_size=page_size,
-                page=self.page,
                 start_datetime=start_dte,
                 end_datetime=end_dte,
             )

--- a/src/qgis_stac/gui/main.py
+++ b/src/qgis_stac/gui/main.py
@@ -154,8 +154,8 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             )
         )
 
-    def display_results(self):
+    def display_results(self, results):
         raise NotImplementedError
 
-    def display_search_error(self):
-        raise NotImplementedError
+    def display_search_error(self, message):
+        self.message_bar.pushMessage(message)

--- a/src/qgis_stac/gui/main.py
+++ b/src/qgis_stac/gui/main.py
@@ -67,6 +67,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         )
 
         self.search_type = ResourceType.FEATURE
+        self.current_progress_message = tr("Searching...")
 
         self.search_started.connect(self.handle_search_start)
         self.search_completed.connect(self.handle_search_end)
@@ -90,10 +91,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.collections_tree.setModel(self.proxy_model)
 
         self.filter_text.textChanged.connect(self.filter_changed)
-        self.collections_tree.selectionModel().\
-            selectionChanged.connect(
-            self.collection_selection_changed
-        )
 
         # prepare sort and filter model for the searched items
         self.items_model = QtGui.QStandardItemModel()
@@ -211,6 +208,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         search operation.
         """
         self.search_type = ResourceType.FEATURE
+        self.current_progress_message = tr("Searching for items...")
 
         start_dte = self.start_dte.dateTime() \
             if self.date_filter_group.isChecked() else None
@@ -233,6 +231,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         """ Searches for the collections available on the
         """
         self.search_type = ResourceType.COLLECTION
+        self.current_progress_message = tr("Searching for collections...")
 
         self.api_client.get_collections()
         self.search_started.emit()
@@ -248,7 +247,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
 
     def handle_search_start(self):
         self.message_bar.clearWidgets()
-        self.show_progress("Searching...")
+        self.show_progress(self.current_progress_message)
         self.update_search_inputs(enabled=False)
 
     def handle_search_end(self):
@@ -256,7 +255,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.update_search_inputs(enabled=True)
 
     def update_search_inputs(self, enabled):
-        self.connections_group.setEnabled(enabled)
+        self.collections_group.setEnabled(enabled)
         self.date_filter_group.setEnabled(enabled)
         self.extent_box.setEnabled(enabled)
         self.metadata_group.setEnabled(enabled)
@@ -316,14 +315,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.message_bar.clearWidgets()
         self.show_message(message, level=Qgis.Critical)
         self.search_completed.emit()
-
-    def collection_selection_changed(self, selected, deselected):
-        collections = self.selected_collections.text()
-        for index in deselected.indexes():
-            collections = collections.replace(f"{index.data(1)},", "")
-        for index in selected.indexes():
-            collections += f"{index.data(1)},"
-        self.selected_collections.setText(collections)
 
     def filter_changed(self, filter_text):
         exp_reg = QtCore.QRegExp(

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -245,6 +245,22 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.api_client.get_collections()
         self.search_started.emit()
 
+    def show_message(
+            self,
+            message,
+            level=Qgis.Warning
+    ):
+        """ Shows message on the main widget message bar
+
+        :param message: Message text
+        :type message: str
+
+        :param level: Message level type
+        :type level: Qgis.MessageLevel
+        """
+        self.message_bar.clearWidgets()
+        self.message_bar.pushMessage(message, level=level)
+
     def show_progress(self, message):
         """ Shows the progress message on the main widget message bar
 

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -107,11 +107,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
 
         self.items_tree.setItemDelegate(self.items_delegate)
 
-        # self.standard_model = QtGui.QStandardItemModel()
-        # self.standard_proxy_model = QtCore.QSortFilterProxyModel()
-        # self.standard_proxy_model.setSourceModel(self.standard_model)
-        # self.items_tree.setModel(self.standard_proxy_model)
-
         self.items_proxy_model = ItemsSortFilterProxyModel(SortField.DATE)
 
         # initialize page
@@ -317,13 +312,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             self.result_items_la.setText(
                 tr("Found {} STAC item(s)").format(len(results))
             )
-            # self.standard_model.removeRows(0, self.model.rowCount())
-            # for result in results:
-            #     item = QtGui.QStandardItem(result.id)
-            #     item.setData(result.id, 1)
-            #     self.standard_model.appendRow(item)
-            #
-            # self.container.setCurrentIndex(1)
 
             items_model = ItemsModel(items=results)
             self.items_proxy_model.setSourceModel(items_model)

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -217,18 +217,20 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.current_progress_message = tr("Searching for items...")
 
         start_dte = self.start_dte.dateTime() \
-            if self.date_filter_group.isChecked() else None
+            if not self.start_dte.dateTime().isNull() else None
         end_dte = self.end_dte.dateTime() \
-            if self.date_filter_group.isChecked() else None
+            if not self.end_dte.dateTime().isNull() else None
 
         collections = self.get_selected_collections()
         page_size = settings_manager.get_current_connection().page_size
+        spatial_extent = self.extent_box.outputExtent()
         self.api_client.get_items(
             ItemSearch(
                 collections=collections,
                 page_size=page_size,
                 start_datetime=start_dte,
                 end_datetime=end_dte,
+                spatial_extent=spatial_extent,
             )
         )
         self.search_started.emit()

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -103,21 +103,16 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.items_delegate = ResultItemDelegate(
             parent=self.items_tree
         )
+        self.standard_model = QtGui.QStandardItemModel()
 
         self.items_tree.setItemDelegate(self.items_delegate)
-        self.items_model = ItemsModel(items=[])
 
-        self.standard_model = QtGui.QStandardItemModel()
-        self.standard_model.setHorizontalHeaderLabels(['Id'])
+        # self.standard_model = QtGui.QStandardItemModel()
+        # self.standard_proxy_model = QtCore.QSortFilterProxyModel()
+        # self.standard_proxy_model.setSourceModel(self.standard_model)
+        # self.items_tree.setModel(self.standard_proxy_model)
 
         self.items_proxy_model = ItemsSortFilterProxyModel(SortField.DATE)
-
-        self.items_proxy_model.setSourceModel(self.standard_model)
-        self.items_filter.textChanged.connect(self.items_filter_changed)
-
-        self.standard_proxy_model = QtCore.QSortFilterProxyModel()
-        self.standard_proxy_model.setSourceModel(self.standard_model)
-        self.items_tree.setModel(self.standard_proxy_model)
 
         # initialize page
         self.page = 1
@@ -322,15 +317,21 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             self.result_items_la.setText(
                 tr("Found {} STAC item(s)").format(len(results))
             )
-            self.standard_model.removeRows(0, self.model.rowCount())
-            for result in results:
-                item = QtGui.QStandardItem(result.id)
-                item.setData(result.id, 1)
-                self.standard_model.appendRow(item)
+            # self.standard_model.removeRows(0, self.model.rowCount())
+            # for result in results:
+            #     item = QtGui.QStandardItem(result.id)
+            #     item.setData(result.id, 1)
+            #     self.standard_model.appendRow(item)
+            #
+            # self.container.setCurrentIndex(1)
 
-            self.standard_proxy_model.setSourceModel(self.standard_model)
+            items_model = ItemsModel(items=results)
+            self.items_proxy_model.setSourceModel(items_model)
 
+            self.items_tree.setModel(self.items_proxy_model)
+            self.items_filter.textChanged.connect(self.items_filter_changed)
             self.container.setCurrentIndex(1)
+
         else:
             raise NotImplementedError
         self.search_completed.emit()
@@ -354,7 +355,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             QtCore.Qt.CaseInsensitive,
             QtCore.QRegExp.FixedString
         )
-        self.standard_proxy_model.setFilterRegExp(exp_reg)
+        self.items_proxy_model.setFilterRegExp(exp_reg)
 
     def get_selected_collections(self):
         indexes = self.collections_tree.selectionModel().selectedIndexes()

--- a/src/qgis_stac/gui/result_item_delegate.py
+++ b/src/qgis_stac/gui/result_item_delegate.py
@@ -1,4 +1,8 @@
-
+# -*- coding: utf-8 -*-
+"""
+    Delegate logic used by the result tab tree view in loading the
+    result item widget.
+"""
 from qgis.PyQt import (
     QtCore,
     QtGui,
@@ -9,6 +13,9 @@ from .result_item_widget import ResultItemWidget
 
 
 class ResultItemDelegate(QtWidgets.QStyledItemDelegate):
+    """ Result item class paints the item result widget into the
+        provided view.
+    """
 
     def __init__(
             self,

--- a/src/qgis_stac/gui/result_item_delegate.py
+++ b/src/qgis_stac/gui/result_item_delegate.py
@@ -1,0 +1,62 @@
+
+from qgis.PyQt import (
+    QtCore,
+    QtGui,
+    QtWidgets
+)
+
+from .result_item_widget import ResultItemWidget
+
+
+class ResultItemDelegate(QtWidgets.QStyledItemDelegate):
+
+    def __init__(
+            self,
+            parent=None,
+    ):
+        super().__init__(parent)
+        self.parent = parent
+        self.index = None
+
+    def paint(
+            self,
+            painter: QtGui.QPainter,
+            option: QtWidgets.QStyleOptionViewItem,
+            index: QtCore.QModelIndex
+    ):
+        item_widget = self.createEditor(self.parent, option, index)
+        item_widget.setGeometry(option.rect)
+        pixmap = item_widget.grab()
+        del item_widget
+        painter.drawPixmap(option.rect.x(), option.rect.y(), pixmap)
+
+    def sizeHint(
+            self,
+            option: QtWidgets.QStyleOptionViewItem,
+            index: QtCore.QModelIndex
+    ):
+        item_widget = self.createEditor(None, option, index)
+        size = item_widget.size()
+        del item_widget
+        return size
+
+    def createEditor(
+            self,
+            parent: QtWidgets.QWidget,
+            option: QtWidgets.QStyleOptionViewItem,
+            index: QtCore.QModelIndex
+    ):
+        proxy_model = index.model()
+        source_index = proxy_model.mapToSource(index)
+        source_model = source_index.model()
+        item = source_model.data(source_index, QtCore.Qt.DisplayRole)
+
+        return ResultItemWidget(item, parent=parent)
+
+    def updateEditorGeometry(
+            self,
+            editor: QtWidgets.QWidget,
+            option: QtWidgets.QStyleOptionViewItem,
+            index: QtCore.QModelIndex
+    ):
+        editor.setGeometry(option.rect)

--- a/src/qgis_stac/gui/result_item_model.py
+++ b/src/qgis_stac/gui/result_item_model.py
@@ -1,4 +1,7 @@
-
+# -*- coding: utf-8 -*-
+"""
+    Contains GUI models used to store search result items.
+"""
 from qgis.PyQt import (
     QtCore,
     QtGui,
@@ -9,6 +12,7 @@ from ..api.models import SortField
 
 
 class ItemsModel(QtCore.QAbstractItemModel):
+    """ Stores the search result items"""
 
     def __init__(self, items, parent=None):
         super().__init__(parent)
@@ -64,6 +68,9 @@ class ItemsModel(QtCore.QAbstractItemModel):
 
 
 class ItemsSortFilterProxyModel(QtCore.QSortFilterProxyModel):
+    """ Handles the custom functionality in sorting and filtering the
+    search items results.
+    """
 
     def __init__(self, current_sort_field, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/qgis_stac/gui/result_item_model.py
+++ b/src/qgis_stac/gui/result_item_model.py
@@ -1,0 +1,89 @@
+
+from qgis.PyQt import (
+    QtCore,
+    QtGui,
+    QtWidgets
+)
+
+from ..api.models import SortField
+
+
+class ItemsModel(QtCore.QAbstractItemModel):
+
+    def __init__(self, items, parent=None):
+        super().__init__(parent)
+        self.items = items
+
+    def index(
+            self,
+            row: int,
+            column: int,
+            parent
+    ):
+        invalid_index = QtCore.QModelIndex()
+        if self.hasIndex(row, column, parent):
+            try:
+                item = self.items[row]
+                result = self.createIndex(row, column, item)
+            except IndexError:
+                result = invalid_index
+        else:
+            result = invalid_index
+        return result
+
+    def parent(self, index: QtCore.QModelIndex):
+        return QtCore.QModelIndex()
+
+    def rowCount(self, index: QtCore.QModelIndex = QtCore.QModelIndex()):
+        return len(self.items)
+
+    def columnCount(self, index: QtCore.QModelIndex = QtCore.QModelIndex()):
+        return 1
+
+    def data(
+            self,
+            index: QtCore.QModelIndex = QtCore.QModelIndex(),
+            role: QtCore.Qt.ItemDataRole = QtCore.Qt.DisplayRole
+    ):
+        result = None
+        if index.isValid():
+            item = index.internalPointer()
+            result = item
+        return result
+
+    def flags(
+            self,
+            index: QtCore.QModelIndex = QtCore.QModelIndex()
+    ):
+        if index.isValid():
+            flags = super().flags(index)
+            result = QtCore.Qt.ItemIsEditable | flags
+        else:
+            result = QtCore.Qt.NoItemFlags
+        return result
+
+
+class ItemsSortFilterProxyModel(QtCore.QSortFilterProxyModel):
+
+    def __init__(self, current_sort_field, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.current_sort_field = current_sort_field
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QtCore.QModelIndex):
+        index = self.sourceModel().index(source_row, 0, source_parent)
+        item = self.sourceModel().data(index)
+        reg_exp = self.filterRegExp()
+        return reg_exp.exactMatch(item)
+
+    def lessThan(self, left: QtCore.QModelIndex, right: QtCore.QModelIndex) -> bool:
+        model = self.sourceModel()
+        left_item = model.data(left)
+        right_item = model.data(right)
+        to_sort = (left_item, right_item)
+
+        if self.current_sort_field == SortField.DATE:
+            result = left_item < right_item
+        else:
+            raise NotImplementedError
+
+        return result

--- a/src/qgis_stac/gui/result_item_model.py
+++ b/src/qgis_stac/gui/result_item_model.py
@@ -69,20 +69,13 @@ class ItemsSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         super().__init__(*args, **kwargs)
         self.current_sort_field = current_sort_field
 
-    def filterAcceptsRow(self, source_row: int, source_parent: QtCore.QModelIndex):
-        index = self.sourceModel().index(source_row, 0, source_parent)
-        item = self.sourceModel().data(index)
-        reg_exp = self.filterRegExp()
-        return reg_exp.exactMatch(item)
-
     def lessThan(self, left: QtCore.QModelIndex, right: QtCore.QModelIndex) -> bool:
         model = self.sourceModel()
         left_item = model.data(left)
         right_item = model.data(right)
-        to_sort = (left_item, right_item)
 
         if self.current_sort_field == SortField.DATE:
-            result = left_item < right_item
+            result = left_item.id < right_item.id
         else:
             raise NotImplementedError
 

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -1,0 +1,24 @@
+import os
+
+from qgis.PyQt import QtWidgets
+from qgis.PyQt.uic import loadUiType
+
+from ..resources import *
+
+
+WidgetUi, _ = loadUiType(
+    os.path.join(os.path.dirname(__file__), "../ui/result_item_widget.ui")
+)
+
+
+class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
+
+    def __init__(
+        self,
+        item,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.item = item
+        self.title_la = item

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -1,9 +1,24 @@
 import os
 
-from qgis.PyQt import QtWidgets
+from functools import partial
+
+from qgis.PyQt import (
+    QtGui,
+    QtCore,
+    QtWidgets,
+    QtNetwork
+)
+
 from qgis.PyQt.uic import loadUiType
 
+from  qgis.core import (
+    QgsApplication,
+    QgsNetworkContentFetcherTask,
+    QgsTask
+)
+
 from ..resources import *
+from ..utils import log
 
 
 WidgetUi, _ = loadUiType(
@@ -22,3 +37,107 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         self.setupUi(self)
         self.item = item
         self.title_la.setText(item.id)
+        self.collection_name.setText(item.collection)
+        self.thumbnail_url = None
+        self.initialize_ui()
+        # if self.thumbnail_url:
+        #     self.add_thumbnail()
+
+    def initialize_ui(self):
+
+        self.created_date.setText(
+            str(self.item.properties.resource_datetime)
+        )
+        layer_types = [
+            "image/tiff; "
+            "application=geotiff; "
+            "profile=cloud-optimized"
+        ]
+
+        for asset in self.item.assets:
+            self.assets_download_box.addItem(
+                asset.title,
+                asset.href
+            )
+            if asset.type in layer_types:
+                self.assets_load_box.addItem(
+                    asset.title,
+                    asset.href
+                )
+            if 'thumbnail' in asset.roles:
+                self.thumbnail_url = asset.href
+
+    def add_thumbnail(self):
+        request = QtNetwork.QNetworkRequest(
+            QtCore.QUrl(
+                self.thumbnail_url
+            )
+        )
+        self.network_task(
+            request,
+            self.thumbnail_response
+        )
+
+    def thumbnail_response(self, content):
+        thumbnail_image = QtGui.QImage.fromData(content)
+
+        if thumbnail_image:
+            thumbnail_pixmap = QtGui.QPixmap.fromImage(thumbnail_image)
+            self.thumbnail_la.setPixmap(thumbnail_pixmap)
+
+    def network_task(
+            self,
+            request,
+            handler,
+            auth_config=""
+    ):
+        """Fetches the response from the given request"""
+        task = QgsNetworkContentFetcherTask(
+            request,
+            authcfg=auth_config
+        )
+        response_handler = partial(
+            self.response,
+            task,
+            handler
+        )
+        task.fetched.connect(response_handler)
+        task.run()
+
+    def response(
+            self,
+            task: QgsNetworkContentFetcherTask,
+            handler
+    ):
+        """Handle the return response """
+        reply = task.reply()
+        error = reply.error()
+        if error == QtNetwork.QNetworkReply.NoError:
+            contents: QtCore.QByteArray = reply.readAll()
+            handler(contents)
+        else:
+            log("Problem fetching response from network")
+
+
+class ThumbnailLoader(QgsTask):
+    def __init__(
+        self,
+        thumbnail_reply: QtCore.QByteArray,
+        label: QtWidgets.QLabel
+    ):
+
+        super().__init__()
+        self.content = thumbnail_reply
+        self.label = label
+        self.thumbnail_image = None
+
+    def run(self):
+        self.thumbnail_image = QtGui.QImage.fromData(self.content)
+        return True
+
+    def finished(self, result: bool):
+        if result:
+            thumbnail_pixmap = QtGui.QPixmap.fromImage(self.thumbnail_image)
+            self.label.setPixmap(thumbnail_pixmap)
+        else:
+            log(f"Couldn't load thumbnail")

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+"""
+    Result item widget, used as a template for each search result item.
+"""
+
 import os
 
 from functools import partial
@@ -20,6 +25,8 @@ from  qgis.core import (
 from ..resources import *
 from ..utils import log
 
+from ..api.models import AssetRoles
+
 
 WidgetUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/result_item_widget.ui")
@@ -27,6 +34,12 @@ WidgetUi, _ = loadUiType(
 
 
 class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
+    """
+     Result item widget class, contains logic for displaying the
+     item properties, loading and downloading item assets as layers,
+     showing the item thumbnail and adding footprint as
+     a layer into QGIS.
+    """
 
     def __init__(
         self,
@@ -44,6 +57,7 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         #     self.add_thumbnail()
 
     def initialize_ui(self):
+        """ Populate UI inputs when loading the widget"""
 
         self.created_date.setText(
             str(self.item.properties.resource_datetime)
@@ -65,10 +79,11 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
                     asset.title,
                     asset.href
                 )
-            if 'thumbnail' in asset.roles:
+            if AssetRoles.THUMBNAIL in asset.roles:
                 self.thumbnail_url = asset.href
 
     def add_thumbnail(self):
+        """ Downloads and loads the STAC Item thumbnail"""
         request = QtNetwork.QNetworkRequest(
             QtCore.QUrl(
                 self.thumbnail_url
@@ -80,6 +95,12 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         )
 
     def thumbnail_response(self, content):
+        """ Callback to handle the thumbnail network response.
+            Sets the thumbnail image data into the widget thumbnail label.
+
+        :param content: Network response data
+        :type content: QByteArray
+        """
         thumbnail_image = QtGui.QImage.fromData(content)
 
         if thumbnail_image:
@@ -92,7 +113,17 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
             handler,
             auth_config=""
     ):
-        """Fetches the response from the given request"""
+        """Fetches the response from the given request.
+
+        :param request: Network request
+        :type request: QNetworkRequest
+
+        :param handler: Callback function to handle the response
+        :type handler: Callable
+
+        :param auth_config: Authentication configuration string
+        :type auth_config: str
+        """
         task = QgsNetworkContentFetcherTask(
             request,
             authcfg=auth_config
@@ -107,10 +138,14 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
 
     def response(
             self,
-            task: QgsNetworkContentFetcherTask,
+            task,
             handler
     ):
-        """Handle the return response """
+        """Handle the return response
+
+        :param task: QGIS task that fetches network content
+        :type task:  QgsNetworkContentFetcherTask
+        """
         reply = task.reply()
         error = reply.error()
         if error == QtNetwork.QNetworkReply.NoError:
@@ -121,6 +156,7 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
 
 
 class ThumbnailLoader(QgsTask):
+    """ Prepares and loads the passed thumbnail into the item widget."""
     def __init__(
         self,
         thumbnail_reply: QtCore.QByteArray,
@@ -133,10 +169,19 @@ class ThumbnailLoader(QgsTask):
         self.thumbnail_image = None
 
     def run(self):
+        """ Operates the main logic of loading the thumbnail data in
+        background.
+        """
         self.thumbnail_image = QtGui.QImage.fromData(self.content)
         return True
 
     def finished(self, result: bool):
+        """ Loads the thumbnail into the widget, if its image data has
+        been successfully loaded.
+
+        :param result: Whether the run() operation finished successfully
+        :type result: bool
+        """
         if result:
             thumbnail_pixmap = QtGui.QPixmap.fromImage(self.thumbnail_image)
             self.label.setPixmap(thumbnail_pixmap)

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -21,4 +21,4 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         super().__init__(parent)
         self.setupUi(self)
         self.item = item
-        self.title_la = item
+        self.title_la.setText(item.id)

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -47,7 +47,8 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
 
         self.created_date.setText(
             str(self.item.properties.resource_datetime)
-        )
+        ) if self.item.properties else None
+
         layer_types = [
             "image/tiff; "
             "application=geotiff; "

--- a/src/qgis_stac/main.py
+++ b/src/qgis_stac/main.py
@@ -20,7 +20,7 @@ from qgis.PyQt.QtWidgets import QAction
 # Initialize Qt resources from file resources.py
 from .resources import *
 
-from .gui.main import QgisStacWidget
+from .gui.qgis_stac_widget import QgisStacWidget
 from .conf import settings_manager
 from .utils import config_defaults_catalogs
 

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -19,9 +19,9 @@
   <property name="windowTitle">
    <string>STAC API Browser</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTabWidget" name="Container">
+    <widget class="QTabWidget" name="container">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -37,7 +37,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QGroupBox" name="connection">
+        <widget class="QGroupBox" name="connections_group">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -131,7 +131,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="date_filter">
+        <widget class="QgsCollapsibleGroupBox" name="date_filter_group">
          <property name="title">
           <string>Filter by date</string>
          </property>
@@ -185,36 +185,32 @@
         </widget>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QgsExtentGroupBox" name="extent_box">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="layoutDirection">
-            <enum>Qt::LeftToRight</enum>
-           </property>
-           <property name="title">
-            <string>Extent (curent layer)</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="flat">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <widget class="QgsExtentGroupBox" name="extent_box">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="title">
+          <string>Extent (curent layer)</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+        </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+        <widget class="QgsCollapsibleGroupBox" name="metadata_group">
          <property name="title">
           <string>Metadata</string>
          </property>
@@ -292,8 +288,33 @@
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="0" column="2">
+          <widget class="QPushButton" name="search_btn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>Search</string>
+           </property>
+           <property name="default">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
           <spacer name="horizontalSpacer_3">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -306,18 +327,18 @@
            </property>
           </spacer>
          </item>
-         <item>
-          <widget class="QPushButton" name="search_btn">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+         <item row="0" column="1">
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
-           <property name="text">
-            <string>Search</string>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
            </property>
-          </widget>
+          </spacer>
          </item>
         </layout>
        </item>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>855</width>
-    <height>734</height>
+    <width>866</width>
+    <height>843</height>
    </rect>
   </property>
   <property name="font">
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">
@@ -131,12 +131,101 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="collections_group_box">
+         <property name="title">
+          <string>Collections</string>
+         </property>
+         <property name="collapsed">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="selected_collections"/>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Selected collections</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Filter </string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="filter_text"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <item>
+             <widget class="QTreeView" name="collections_tree">
+              <property name="editTriggers">
+               <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::MultiSelection</enum>
+              </property>
+              <property name="indentation">
+               <number>5</number>
+              </property>
+              <property name="sortingEnabled">
+               <bool>true</bool>
+              </property>
+              <property name="allColumnsShowFocus">
+               <bool>true</bool>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QPushButton" name="fetch_collections_btn">
+              <property name="text">
+               <string>Fetch collections</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBox" name="date_filter_group">
          <property name="title">
           <string>Filter by date</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
          <property name="collapsed">
           <bool>false</bool>
@@ -156,28 +245,38 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QgsDateTimeEdit" name="start_dte">
+          <item row="1" column="1">
+           <widget class="QgsDateTimeEdit" name="end_dte">
             <property name="dateTime">
              <datetime>
-              <hour>22</hour>
-              <minute>5</minute>
+              <hour>0</hour>
+              <minute>0</minute>
               <second>0</second>
-              <year>2000</year>
+              <year>2021</year>
               <month>12</month>
               <day>1</day>
              </datetime>
             </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QgsDateTimeEdit" name="end_dte">
             <property name="date">
              <date>
-              <year>2000</year>
+              <year>2021</year>
               <month>12</month>
               <day>1</day>
              </date>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QgsDateTimeEdit" name="start_dte">
+            <property name="dateTime">
+             <datetime>
+              <hour>0</hour>
+              <minute>0</minute>
+              <second>0</second>
+              <year>2021</year>
+              <month>1</month>
+              <day>1</day>
+             </datetime>
             </property>
            </widget>
           </item>
@@ -205,7 +304,10 @@
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
          <property name="flat">
-          <bool>false</bool>
+          <bool>true</bool>
+         </property>
+         <property name="collapsed">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -217,8 +319,11 @@
          <property name="checkable">
           <bool>true</bool>
          </property>
-         <property name="collapsed">
+         <property name="checked">
           <bool>false</bool>
+         </property>
+         <property name="collapsed">
+          <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
@@ -344,138 +449,171 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="Results">
+     <widget class="QWidget" name="results">
       <attribute name="title">
        <string>Results</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8">
        <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Results page</string>
+        <widget class="QScrollArea" name="scroll_area">
+         <property name="styleSheet">
+          <string notr="true"/>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_9">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_11"/>
-          </item>
-          <item>
-           <widget class="QWidget" name="pagination" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_12">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_5">
-               <property name="sizeConstraint">
-                <enum>QLayout::SetMinimumSize</enum>
-               </property>
-               <item>
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Expanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QPushButton" name="previous_btn">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Go to previous page&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="text">
-                  <string>Previous</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="next_btn">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Go to next page&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="text">
-                  <string>Next</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="sort_field_cmb">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="reverse_order_chb">
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="layoutDirection">
-                  <enum>Qt::LeftToRight</enum>
-                 </property>
-                 <property name="text">
-                  <string>Reverse order</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_9">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="styleSheet">
-                  <string notr="true"/>
-                 </property>
-                 <property name="text">
-                  <string>Sort by</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>sort_field_cmb</cstring>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>824</width>
+            <height>741</height>
+           </rect>
+          </property>
+          <widget class="QTreeView" name="items_tree">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>1</y>
+             <width>861</width>
+             <height>741</height>
+            </rect>
+           </property>
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="indentation">
+            <number>5</number>
+           </property>
+           <property name="sortingEnabled">
+            <bool>true</bool>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </widget>
         </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="pagination">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="previous_btn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Go to previous page&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Previous</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="next_btn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Go to next page&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Next</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="sort_field_cmb">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_9">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>Sort by</string>
+           </property>
+           <property name="buddy">
+            <cstring>sort_field_cmb</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="reverse_order_chb">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LeftToRight</enum>
+           </property>
+           <property name="text">
+            <string>Reverse order</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="settings">
       <attribute name="title">
        <string>Settings</string>
       </attribute>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">
@@ -131,7 +131,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="collections_group_box">
+        <widget class="QgsCollapsibleGroupBox" name="collections_group">
          <property name="title">
           <string>Collections</string>
          </property>
@@ -141,25 +141,22 @@
          <layout class="QVBoxLayout" name="verticalLayout_10">
           <item>
            <layout class="QGridLayout" name="gridLayout_4">
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="selected_collections"/>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Selected collections</string>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="filter_text">
+              <property name="toolTip">
+               <string>Filter and search the fetched collections, using the title property.</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
+            <item row="3" column="0">
              <widget class="QLabel" name="label_2">
+              <property name="toolTip">
+               <string>Filter and search the fetched collections, using the title property.</string>
+              </property>
               <property name="text">
-               <string>Filter </string>
+               <string>Search for collection</string>
               </property>
              </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QLineEdit" name="filter_text"/>
             </item>
            </layout>
           </item>
@@ -167,6 +164,9 @@
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
              <widget class="QTreeView" name="collections_tree">
+              <property name="toolTip">
+               <string>Click on an item to select the collection.</string>
+              </property>
               <property name="editTriggers">
                <set>QAbstractItemView::NoEditTriggers</set>
               </property>
@@ -193,6 +193,9 @@
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
              <widget class="QPushButton" name="fetch_collections_btn">
+              <property name="toolTip">
+               <string>Get all collections provided by the current STAC API connection</string>
+              </property>
               <property name="text">
                <string>Fetch collections</string>
               </property>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>866</width>
-    <height>869</height>
+    <height>892</height>
    </rect>
   </property>
   <property name="font">
@@ -107,6 +107,9 @@
             </item>
             <item>
              <widget class="QPushButton" name="load_connection_btn">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
               <property name="toolTip">
                <string>Load connections from file</string>
               </property>
@@ -117,6 +120,9 @@
             </item>
             <item>
              <widget class="QPushButton" name="save_connection_btn">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
               <property name="toolTip">
                <string>Save connections to file</string>
               </property>
@@ -164,6 +170,9 @@
            <widget class="QLabel" name="result_collections_la">
             <property name="text">
              <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -232,7 +241,7 @@
           <string>Filter by date</string>
          </property>
          <property name="checkable">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="checked">
           <bool>false</bool>
@@ -327,7 +336,7 @@
           <string>Metadata</string>
          </property>
          <property name="checkable">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="checked">
           <bool>false</bool>
@@ -549,48 +558,25 @@
         </widget>
        </item>
        <item>
-        <widget class="QScrollArea" name="scrollArea">
-         <property name="widgetResizable">
+        <widget class="QTreeView" name="items_tree">
+         <property name="editTriggers">
+          <set>QAbstractItemView::AllEditTriggers</set>
+         </property>
+         <property name="indentation">
+          <number>5</number>
+         </property>
+         <property name="sortingEnabled">
           <bool>true</bool>
          </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>824</width>
-            <height>709</height>
-           </rect>
-          </property>
-          <widget class="QTreeView" name="items_tree">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>0</y>
-             <width>821</width>
-             <height>711</height>
-            </rect>
-           </property>
-           <property name="editTriggers">
-            <set>QAbstractItemView::AllEditTriggers</set>
-           </property>
-           <property name="indentation">
-            <number>5</number>
-           </property>
-           <property name="sortingEnabled">
-            <bool>true</bool>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="headerHidden">
-            <bool>true</bool>
-           </property>
-           <attribute name="headerVisible">
-            <bool>false</bool>
-           </attribute>
-          </widget>
-         </widget>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="headerHidden">
+          <bool>true</bool>
+         </property>
+         <attribute name="headerVisible">
+          <bool>false</bool>
+         </attribute>
         </widget>
        </item>
        <item>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>866</width>
-    <height>843</height>
+    <height>869</height>
    </rect>
   </property>
   <property name="font">
@@ -161,6 +161,13 @@
            </layout>
           </item>
           <item>
+           <widget class="QLabel" name="result_collections_la">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
              <widget class="QTreeView" name="collections_tree">
@@ -234,6 +241,13 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>Start</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="1">
            <widget class="QLabel" name="label_14">
             <property name="text">
@@ -241,10 +255,17 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_13">
-            <property name="text">
-             <string>Start</string>
+          <item row="1" column="0">
+           <widget class="QgsDateTimeEdit" name="start_dte">
+            <property name="dateTime">
+             <datetime>
+              <hour>0</hour>
+              <minute>0</minute>
+              <second>0</second>
+              <year>2021</year>
+              <month>1</month>
+              <day>1</day>
+             </datetime>
             </property>
            </widget>
           </item>
@@ -266,20 +287,6 @@
               <month>12</month>
               <day>1</day>
              </date>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QgsDateTimeEdit" name="start_dte">
-            <property name="dateTime">
-             <datetime>
-              <hour>0</hour>
-              <minute>0</minute>
-              <second>0</second>
-              <year>2021</year>
-              <month>1</month>
-              <day>1</day>
-             </datetime>
             </property>
            </widget>
           </item>
@@ -310,7 +317,7 @@
           <bool>true</bool>
          </property>
          <property name="collapsed">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
         </widget>
        </item>
@@ -458,21 +465,93 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8">
        <item>
-        <widget class="QScrollArea" name="scroll_area">
-         <property name="styleSheet">
-          <string notr="true"/>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="0" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Filter</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="items_filter">
+             <property name="toolTip">
+              <string>Filter by item title</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="0" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QLabel" name="label_9">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="styleSheet">
+              <string notr="true"/>
+             </property>
+             <property name="text">
+              <string>Sort by</string>
+             </property>
+             <property name="buddy">
+              <cstring>sort_field_cmb</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="sort_field_cmb">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="reverse_order_chb">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>Reverse order</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="result_items_la">
+         <property name="text">
+          <string/>
          </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
-         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
          <property name="widgetResizable">
           <bool>true</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
          <widget class="QWidget" name="scrollAreaWidgetContents">
           <property name="geometry">
@@ -480,20 +559,20 @@
             <x>0</x>
             <y>0</y>
             <width>824</width>
-            <height>741</height>
+            <height>709</height>
            </rect>
           </property>
           <widget class="QTreeView" name="items_tree">
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>1</y>
-             <width>861</width>
-             <height>741</height>
+             <y>0</y>
+             <width>821</width>
+             <height>711</height>
             </rect>
            </property>
            <property name="editTriggers">
-            <set>QAbstractItemView::NoEditTriggers</set>
+            <set>QAbstractItemView::AllEditTriggers</set>
            </property>
            <property name="indentation">
             <number>5</number>
@@ -504,6 +583,12 @@
            <property name="wordWrap">
             <bool>true</bool>
            </property>
+           <property name="headerHidden">
+            <bool>true</bool>
+           </property>
+           <attribute name="headerVisible">
+            <bool>false</bool>
+           </attribute>
           </widget>
          </widget>
         </widget>
@@ -531,6 +616,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="previous_btn">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
              <horstretch>0</horstretch>
@@ -547,6 +635,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="next_btn">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
              <horstretch>0</horstretch>
@@ -558,57 +649,6 @@
            </property>
            <property name="text">
             <string>Next</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="sort_field_cmb">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_9">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string>Sort by</string>
-           </property>
-           <property name="buddy">
-            <cstring>sort_field_cmb</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="reverse_order_chb">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="layoutDirection">
-            <enum>Qt::LeftToRight</enum>
-           </property>
-           <property name="text">
-            <string>Reverse order</string>
            </property>
           </widget>
          </item>

--- a/src/qgis_stac/ui/result_item_widget.ui
+++ b/src/qgis_stac/ui/result_item_widget.ui
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResultItemWidget</class>
+ <widget class="QWidget" name="ResultItemWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>768</width>
+    <height>222</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>222</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">background-color: rgb(255, 255, 255);</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="resource">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QLabel" name="title_la">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="text">
+           <string>Title</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="resource_type_icon_la">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Date acquired</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="created_date">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="description_la">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>New description</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="action_buttons_layout">
+          <item>
+           <widget class="QToolButton" name="add_footprint">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open resource in Browser&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Add footprint</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="add_assests_box">
+            <item>
+             <property name="text">
+              <string>Add assets as layers</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="comboBox">
+            <item>
+             <property name="text">
+              <string>Download assests</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QLabel" name="thumbnail_la">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>200</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="text">
+           <string>Thumbnail</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qgis_stac/ui/result_item_widget.ui
+++ b/src/qgis_stac/ui/result_item_widget.ui
@@ -94,7 +94,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Date acquired</string>
+             <string>Date acquired:</string>
             </property>
            </widget>
           </item>
@@ -120,7 +120,7 @@
          </layout>
         </item>
         <item>
-         <widget class="QLabel" name="description_la">
+         <widget class="QLabel" name="collection_name">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
@@ -144,7 +144,7 @@
         <item>
          <layout class="QHBoxLayout" name="action_buttons_layout">
           <item>
-           <widget class="QToolButton" name="add_footprint">
+           <widget class="QToolButton" name="footprint_box">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open resource in Browser&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -154,7 +154,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="add_assests_box">
+           <widget class="QComboBox" name="assets_box">
             <item>
              <property name="text">
               <string>Add assets as layers</string>
@@ -163,7 +163,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="comboBox">
+           <widget class="QComboBox" name="assets_download_box">
             <item>
              <property name="text">
               <string>Download assests</string>

--- a/src/qgis_stac/ui/result_item_widget.ui
+++ b/src/qgis_stac/ui/result_item_widget.ui
@@ -154,7 +154,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="assets_box">
+           <widget class="QComboBox" name="assets_load_box">
             <item>
              <property name="text">
               <string>Add assets as layers</string>
@@ -166,7 +166,7 @@
            <widget class="QComboBox" name="assets_download_box">
             <item>
              <property name="text">
-              <string>Download assests</string>
+              <string>Download assets</string>
              </property>
             </item>
            </widget>

--- a/src/qgis_stac/utils.py
+++ b/src/qgis_stac/utils.py
@@ -57,7 +57,7 @@ def log(
         message,
         name,
         level=level,
-        notify_user=notify,
+        notifyUser=notify,
     )
 
 

--- a/src/qgis_stac/utils.py
+++ b/src/qgis_stac/utils.py
@@ -6,6 +6,7 @@ import uuid
 import datetime
 
 from qgis.PyQt import QtCore
+from qgis.core import Qgis, QgsMessageLog
 from .conf import (
     ConnectionSettings,
     settings_manager
@@ -26,6 +27,38 @@ def tr(message):
     """
     # noinspection PyTypeChecker,PyArgumentList,PyCallByClass
     return QtCore.QCoreApplication.translate("QgisStac", message)
+
+
+def log(
+        message: str,
+        name: str = "qgis_stac",
+        info: bool = True,
+        notify: bool = True,
+):
+    """ Logs the message into QGIS logs using qgis_stac as the default
+    log instance.
+    If notify_user is True, user will be notified about the log.
+
+    :param message: The log message
+    :type message: str
+
+    :param name: Name of te log instance, qgis_stac is the default
+    :type message: str
+
+    :param info: Whether the message is about info or a
+    warning
+    :type info: bool
+
+    :param notify: Whether to notify user about the log
+    :type notify: bool
+     """
+    level = Qgis.Info if info else Qgis.Warning
+    QgsMessageLog.logMessage(
+        message,
+        name,
+        level=level,
+        notify_user=notify,
+    )
 
 
 def config_defaults_catalogs():


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/21, https://github.com/stac-utils/qgis-stac-plugin/issues/22 and https://github.com/stac-utils/qgis-stac-plugin/issues/31

Adds search logic in the plugin, now collections can be used when searching, results are shown using the search item result widget template.

Searching items current workflow

![searching_items](https://user-images.githubusercontent.com/2663775/144868091-b05df7a1-b0c9-4e75-b342-e728449d453f.gif)

Remaining issues

- [x] updates in the format used when querying extent and datetimes.
- [ ]  implement pagination
- [ ]  fix bug when loading thumbnails
- [x]  docs for the new changes