### PR TITLE
Fix when adding layers and thumbnails

### DIFF
--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -45,6 +45,7 @@ class AssetRoles(enum.Enum):
 class AssetLayerType(enum.Enum):
     """ Types of assets layers that can be added to QGIS"""
     COG = 'profile=cloud-optimized'
+    VECTOR = 'ogr'
 
 
 class SortField(enum.Enum):
@@ -244,6 +245,7 @@ class ItemSearch:
 
 @dataclasses.dataclass
 class SearchFilters:
+    """ Stores search filters inputs"""
     page: typing.Optional[int] = 1
     page_size: typing.Optional[int] = 10
     collections: typing.Optional[list] = None

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -70,15 +70,7 @@ class ContentFetcherTask(QgsTask):
                 response = self.client.search(
                     **self.search_params.params()
                 )
-                pages = 1
-                items = 0
                 self.pagination = ResourcePagination()
-                # for i, page in enumerate(response.get_item_collections()):
-                #     pages = pages + i
-                #     items += len(page.items)
-                # self.pagination.total_pages = pages
-                # self.pagination.total_items = items
-                #
                 for i, collection in enumerate(response.get_item_collections()):
                     if self.search_params.page == (i + 1):
                         self.response = collection

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -298,6 +298,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         :param message: Progress message
         :type message: str
         """
+        self.message_bar.clearWidgets()
         message_bar_item = self.message_bar.createMessage(message)
         progress_bar = QtWidgets.QProgressBar()
         progress_bar.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -21,10 +21,7 @@ from ..api.models import ItemSearch, ResourceType
 from ..api.client import Client
 from ..api.models import SearchFilters, SortField
 
-from .result_item_delegate import ResultItemDelegate
-from .result_item_model import ItemsModel, ItemsSortFilterProxyModel
-
-from ..utils import tr
+from ..utils import tr, log
 
 from .result_item_widget import ResultItemWidget
 
@@ -88,6 +85,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
 
         self.grid_layout = QtWidgets.QGridLayout()
         self.message_bar = QgsMessageBar()
+        self.progress_bar = None
         self.prepare_message_bar()
 
         self.prepare_extent_box()
@@ -104,18 +102,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
 
         self.filter_text.textChanged.connect(self.filter_changed)
 
-        # prepare sort and filter model for the searched items
-        self.items_tree.setIndentation(0)
-        self.items_tree.verticalScrollBar().setSingleStep(10)
-
-        self.items_delegate = ResultItemDelegate(
-            main_widget=self,
-            parent=self.items_tree
-        )
-        self.standard_model = QtGui.QStandardItemModel()
-        self.items_tree.setItemDelegate(self.items_delegate)
-        self.items_proxy_model = ItemsSortFilterProxyModel(SortField.ID)
-
         # initialize page
         self.page = 1
         self.total_pages = 0
@@ -128,7 +114,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.extent_box.extentChanged.connect(self.save_filters)
 
         self.populate_sorting_field()
-        self.sort_cmb.activated.connect(self.sort_items)
 
     def add_connection(self):
         """ Adds a new connection into the plugin, then updates
@@ -222,7 +207,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
 
     def search_items_api(self):
         self.current_progress_message = tr(
-            f"Searching items ..."
+            "Searching items..."
         )
         self.page = 1
         self.search_items()
@@ -230,14 +215,14 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
     def previous_items(self):
         self.page -= 1
         self.current_progress_message = tr(
-            f"Retrieving data"
+            "Retrieving previous page..."
         )
         self.search_items()
 
     def next_items(self):
         self.page += 1
         self.current_progress_message = tr(
-            f"Retrieving data"
+            "Retrieving next page..."
         )
         self.search_items()
 
@@ -294,20 +279,41 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.message_bar.clearWidgets()
         self.message_bar.pushMessage(message, level=level)
 
-    def show_progress(self, message):
+    def show_progress(self, message, minimum=0, maximum=0):
         """ Shows the progress message on the main widget message bar
 
         :param message: Progress message
         :type message: str
+
+        :param minimum: Minimum value that can be set on the progress bar
+        :type minimum: int
+
+        :param maximum: Maximum value that can be set on the progress bar
+        :type maximum: int
         """
         self.message_bar.clearWidgets()
         message_bar_item = self.message_bar.createMessage(message)
-        progress_bar = QtWidgets.QProgressBar()
-        progress_bar.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
-        progress_bar.setMinimum(0)
-        progress_bar.setMaximum(0)
-        message_bar_item.layout().addWidget(progress_bar)
+        self.progress_bar = QtWidgets.QProgressBar()
+        self.progress_bar.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
+        self.progress_bar.setMinimum(minimum)
+        self.progress_bar.setMaximum(maximum)
+        message_bar_item.layout().addWidget(self.progress_bar)
         self.message_bar.pushWidget(message_bar_item, Qgis.Info)
+
+    def update_progress_bar(self, value):
+        """Sets the value of the progress bar
+
+        :param value: Value to be set on the progress bar
+        :type value: int
+        """
+        if self.progress_bar:
+            try:
+                self.progress_bar.setValue(value)
+            except RuntimeError:
+                log(
+                    tr("Error setting value to a progress bar"),
+                    notify=False
+                )
 
     def handle_search_start(self):
         """ Handles the logic to be executed when searching has started"""
@@ -369,6 +375,9 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
 
         :param results: Search results
         :return: list
+
+        :param pagination: Pagination details
+        :type pagination: ResourcePagination
         """
         if self.search_type == ResourceType.COLLECTION:
             self.model.removeRows(0, self.model.rowCount())
@@ -391,14 +400,8 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
                     )
                 )
             self.total_pages = pagination.total_pages
-            self.populate_test_page(results)
-            #
-            # items_model = ItemsModel(items=results)
-            # self.items_proxy_model.setSourceModel(items_model)
-            #
-            # self.items_tree.setModel(self.items_proxy_model)
-            # self.items_filter.textChanged.connect(self.items_filter_changed)
-            self.container.setCurrentIndex(2)
+            self.populate_results(results)
+            self.container.setCurrentIndex(1)
 
         else:
             raise NotImplementedError
@@ -415,7 +418,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.show_message(message, level=Qgis.Critical)
         self.search_completed.emit()
 
-    def populate_test_page(self, results):
+    def populate_results(self, results):
         scroll_container = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(1, 1, 1, 1)
@@ -457,12 +460,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         :param filter_text: Filter text
         :type: str
         """
-        # TODO update to user QtCore.QRegExp, QRegularExpression will be
-        # deprecated.
-        options = QtCore.QRegularExpression.NoPatternOption
-        options |= QtCore.QRegularExpression.CaseInsensitiveOption
-        regular_expression = QtCore.QRegularExpression(filter_text, options)
-        self.items_proxy_model.setFilterRegularExpression(regular_expression)
+        raise NotImplementedError
 
     def populate_sorting_field(self):
         """" Initializes sorting field combo box list items"""
@@ -485,14 +483,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         :param index: Current index of the sort fields list
         :type index: int
         """
-        sort_field = self.sort_cmb.itemData(index)
-        self.items_proxy_model.set_sort_field(sort_field)
-        order = QtCore.Qt.AscendingOrder \
-            if not self.reverse_order_box.isChecked() \
-            else QtCore.Qt.DescendingOrder
-        self.items_proxy_model.sort(index, order)
-        # Force refresh of the tree view items
-        self.items_tree.setModel(self.items_proxy_model)
+        raise NotImplementedError
 
     def get_selected_collections(self):
         """ Gets the currently selected collections ids from the collection

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -468,7 +468,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         labels = {
             SortField.ID: tr("Name"),
             SortField.COLLECTION: tr("Collection"),
-            # SortField.DATE: tr("Date")
         }
         for ordering_type, item_text in labels.items():
             self.sort_cmb.addItem(item_text, ordering_type)

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -26,6 +26,8 @@ from .result_item_model import ItemsModel, ItemsSortFilterProxyModel
 
 from ..utils import tr
 
+from .result_item_widget import ResultItemWidget
+
 WidgetUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/qgis_stac_widget.ui")
 )
@@ -389,13 +391,14 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
                     )
                 )
             self.total_pages = pagination.total_pages
-
-            items_model = ItemsModel(items=results)
-            self.items_proxy_model.setSourceModel(items_model)
-
-            self.items_tree.setModel(self.items_proxy_model)
-            self.items_filter.textChanged.connect(self.items_filter_changed)
-            self.container.setCurrentIndex(1)
+            self.populate_test_page(results)
+            #
+            # items_model = ItemsModel(items=results)
+            # self.items_proxy_model.setSourceModel(items_model)
+            #
+            # self.items_tree.setModel(self.items_proxy_model)
+            # self.items_filter.textChanged.connect(self.items_filter_changed)
+            self.container.setCurrentIndex(2)
 
         else:
             raise NotImplementedError
@@ -411,6 +414,25 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.message_bar.clearWidgets()
         self.show_message(message, level=Qgis.Critical)
         self.search_completed.emit()
+
+    def populate_test_page(self, results):
+        scroll_container = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(1, 1, 1, 1)
+        layout.setSpacing(1)
+        for result in results:
+            search_result_widget = ResultItemWidget(
+                result,
+                main_widget=self,
+                parent=self
+            )
+            layout.addWidget(search_result_widget)
+            layout.setAlignment(search_result_widget, QtCore.Qt.AlignTop)
+        scroll_container.setLayout(layout)
+        self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setWidget(scroll_container)
 
     def filter_changed(self, filter_text):
         """

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -28,7 +28,7 @@ from  qgis.core import (
 )
 
 from ..resources import *
-from ..utils import log
+from ..utils import log, tr
 
 from ..api.models import AssetLayerType, AssetRoles
 
@@ -94,7 +94,6 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
                 self.thumbnail_url = asset.href
 
         self.assets_load_box.activated.connect(self.load_asset)
-        # self.assets_load_box.currentIndexChanged(self.load_asset)
 
     def update_inputs(self, enabled):
         self.assets_load_box.setEnabled(enabled)
@@ -107,6 +106,7 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         if self.assets_load_box.count() < 1 or index < 1:
             return
         assert_type = self.assets_load_box.itemData(index)['type']
+        layer_type = QgsMapLayer.RasterLayer
 
         if AssetLayerType.COG.value in assert_type:
             asset_href = f"{self.cog_string}" \
@@ -119,7 +119,7 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         layer_loader = LayerLoader(
             asset_href,
             asset_name,
-            QgsMapLayer.RasterLayer,
+            layer_type,
             self.add_layer,
             self.handle_layer_error
         )
@@ -128,7 +128,7 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
             f"Adding asset {asset_name} into QGIS"
         )
 
-        log("Started adding asset into QGIS")
+        log(tr("Started adding asset into QGIS"))
         QgsApplication.taskManager().addTask(layer_loader)
 
     def add_layer(self, layer):
@@ -139,10 +139,11 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         """
         QgsProject.instance().addMapLayer(layer)
         self.update_inputs(True)
+        message = tr("Sucessfully added asset into QGIS")
         self.main_widget.show_message(
-            "Sucessfully added asset into QGIS"
+            message
         )
-        log("Successfully added asset into QGIS")
+        log(message)
 
     def handle_layer_error(self, message):
         """ Handles the error message from the layer loading task
@@ -226,7 +227,7 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
             contents: QtCore.QByteArray = reply.readAll()
             handler(contents)
         else:
-            log("Problem fetching response from network")
+            log(tr("Problem fetching response from network"))
 
 
 class ThumbnailLoader(QgsTask):
@@ -260,7 +261,7 @@ class ThumbnailLoader(QgsTask):
             thumbnail_pixmap = QtGui.QPixmap.fromImage(self.thumbnail_image)
             self.label.setPixmap(thumbnail_pixmap)
         else:
-            log("Couldn't load thumbnail")
+            log(tr("Couldn't load thumbnail"))
 
 
 class LayerLoader(QgsTask):
@@ -286,7 +287,7 @@ class LayerLoader(QgsTask):
         """ Operates the main layers loading logic
         """
         log(
-            "Fetching layers in a background task."
+            tr("Fetching layers in a background task.")
         )
         if self.layer_type is QgsMapLayer.RasterLayer:
             self.layer = QgsRasterLayer(

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -13,10 +13,10 @@ from qgis.PyQt import (
     QtWidgets,
     QtNetwork
 )
-
 from qgis.PyQt.uic import loadUiType
 
-from  qgis.core import (
+from qgis.core import (
+    Qgis,
     QgsApplication,
     QgsMapLayer,
     QgsNetworkContentFetcherTask,
@@ -60,9 +60,10 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         self.thumbnail_url = None
         self.cog_string = '/vsicurl/'
         self.main_widget = main_widget
+        self.layer_loader = None
         self.initialize_ui()
-        # if self.thumbnail_url:
-        #     self.add_thumbnail()
+        if self.thumbnail_url:
+            self.add_thumbnail()
 
     def initialize_ui(self):
         """ Populate UI inputs when loading the widget"""
@@ -94,14 +95,33 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
                 self.thumbnail_url = asset.href
 
         self.assets_load_box.activated.connect(self.load_asset)
+        # make sure the palette highlight colors are the same
+        self.assets_load_box.setStyleSheet(
+            'selection-background-color: rgb(32, 100, 189);'
+            'selection-color: white;'
+        )
+        self.assets_download_box.setStyleSheet(
+            'selection-background-color: rgb(32, 100, 189);'
+            'selection-color: white;'
+        )
 
     def update_inputs(self, enabled):
+        """ Updates the inputs widgets state in the main search item widget.
+
+        :param enabled: Whether to enable the inputs or disable them.
+        :type enabled: bool
+        """
         self.assets_load_box.setEnabled(enabled)
         self.assets_download_box.setEnabled(enabled)
         self.footprint_box.setEnabled(enabled)
 
     def load_asset(self, index):
-        """ Loads asset into QGIS"""
+        """ Loads asset into QGIS.
+            Checks if the asset type is a loadable layer inside QGIS.
+
+        :param index: Index of the selected combo box item
+        :type index: int
+        """
 
         if self.assets_load_box.count() < 1 or index < 1:
             return
@@ -116,34 +136,64 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         asset_name = self.assets_load_box.itemText(index)
 
         self.update_inputs(False)
-        layer_loader = LayerLoader(
+        self.layer_loader = LayerLoader(
             asset_href,
             asset_name,
-            layer_type,
-            self.add_layer,
-            self.handle_layer_error
+            layer_type
         )
+
+        # Using signal approach to detect the results of the layer loader
+        # task as the callback function approach doesn't make the task
+        # to recall the assigned callbacks in the provided context.
+        self.layer_loader.taskCompleted.connect(self.add_layer)
+        self.layer_loader.progressChanged.connect(self.main_widget.update_progress_bar)
+        self.layer_loader.taskTerminated.connect(self.layer_loader_terminated)
+
+        QgsApplication.taskManager().addTask(self.layer_loader)
 
         self.main_widget.show_progress(
-            f"Adding asset {asset_name} into QGIS"
+            f"Adding asset \"{asset_name}\" into QGIS",
+            minimum=0,
+            maximum=100,
         )
-
+        self.main_widget.update_progress_bar(0)
         log(tr("Started adding asset into QGIS"))
-        QgsApplication.taskManager().addTask(layer_loader)
 
-    def add_layer(self, layer):
-        """ Adds layer into the current QGIS project
-
-        :param layer: QGIS layer
-        :type layer: QgsMapLayer
+    def add_layer(self):
+        """ Adds layer into the current QGIS project.
+            For the layer to be added successfully, the task for loading
+            layer need to exist and the corresponding layer need to be
+            available.
         """
-        QgsProject.instance().addMapLayer(layer)
+        if self.layer_loader and self.layer_loader.layer:
+            layer = self.layer_loader.layer
+            QgsProject.instance().addMapLayer(layer)
+
+            message = tr("Sucessfully added asset as a map layer")
+            level = Qgis.Info
+        elif self.layer_loader and self.layer_loader.error:
+            message = self.layer_loader.error
+            level = Qgis.Critical
+        else:
+            message = tr("Problem fetching asset and loading it, into QGIS")
+            level = Qgis.Critical
+
         self.update_inputs(True)
-        message = tr("Sucessfully added asset into QGIS")
-        self.main_widget.show_message(
-            message
-        )
         log(message)
+        self.main_widget.show_message(
+            message,
+            level=level
+        )
+
+    def layer_loader_terminated(self):
+        """ Shows message to user when layer loading task has been terminated"""
+        message = tr("QGIS background task for loading assets was terminated.")
+        self.update_inputs(True)
+        log(message)
+        self.main_widget.show_message(
+            message,
+            level=Qgis.Critical
+        )
 
     def handle_layer_error(self, message):
         """ Handles the error message from the layer loading task
@@ -152,10 +202,10 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         :type message: str
         """
         self.update_inputs(True)
+        log(message)
         self.main_widget.show_message(
             message
         )
-        log(message)
 
     def add_thumbnail(self):
         """ Downloads and loads the STAC Item thumbnail"""
@@ -270,17 +320,14 @@ class LayerLoader(QgsTask):
         self,
         layer_uri,
         layer_name,
-        layer_type,
-        handler,
-        error_handler
+        layer_type
     ):
 
         super().__init__()
         self.layer_uri = layer_uri
         self.layer_name = layer_name
         self.layer_type = layer_type
-        self.handler = handler
-        self.error_handler = error_handler
+        self.error = None
         self.layer = None
 
     def run(self):
@@ -299,7 +346,7 @@ class LayerLoader(QgsTask):
             self.layer = QgsVectorLayer(
                 self.layer_uri,
                 self.layer_name,
-                "ogr"
+                AssetLayerType.VECTOR.value
             )
             return self.layer.isValid()
         else:
@@ -316,23 +363,21 @@ class LayerLoader(QgsTask):
         """
         if result and self.layer:
             log(
-                f"Successfully fetched layer with URI"
+                f"Fetched layer with URI"
                 f"{self.layer_uri} "
             )
             # Due to the way QGIS is handling layers sharing between tasks and
             # the main thread, sending the layer to the main thread
-            # without cloning it can lead to unpredicted crashes, hence we clone
-            # the layer before sharing it with the main thread.
-            layer = self.layer.clone()
-            self.handler(layer)
+            # without cloning it can lead to unpredicted crashes,
+            # hence we clone the layer before storing it, so it can
+            # be used in the main thread.
+            self.layer = self.layer.clone()
         else:
-            log(
+            self.error = tr(
                 f"Couldn't load layer "
-                f"{self.layer_uri}, "
-                f"error {self.layer.dataProvider().error()}"
-            )
-            self.error_handler(
-                f"Problem adding layer into QGIS,"
                 f"{self.layer_uri},"
                 f"error {self.layer.dataProvider().error()}"
+            )
+            log(
+                self.error
             )

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>866</width>
-    <height>892</height>
+    <width>940</width>
+    <height>897</height>
    </rect>
   </property>
   <property name="font">
@@ -642,6 +642,30 @@
           </widget>
          </item>
         </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="test">
+      <attribute name="title">
+       <string>Page</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_9">
+       <item>
+        <widget class="QScrollArea" name="scroll_area">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>898</width>
+            <height>828</height>
+           </rect>
+          </property>
+         </widget>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -554,32 +554,27 @@
         </layout>
        </item>
        <item>
+        <widget class="QScrollArea" name="scroll_area">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>898</width>
+            <height>737</height>
+           </rect>
+          </property>
+         </widget>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="result_items_la">
          <property name="text">
           <string/>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTreeView" name="items_tree">
-         <property name="editTriggers">
-          <set>QAbstractItemView::AllEditTriggers</set>
-         </property>
-         <property name="indentation">
-          <number>5</number>
-         </property>
-         <property name="sortingEnabled">
-          <bool>true</bool>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="headerHidden">
-          <bool>true</bool>
-         </property>
-         <attribute name="headerVisible">
-          <bool>false</bool>
-         </attribute>
         </widget>
        </item>
        <item>
@@ -642,30 +637,6 @@
           </widget>
          </item>
         </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="test">
-      <attribute name="title">
-       <string>Page</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_9">
-       <item>
-        <widget class="QScrollArea" name="scroll_area">
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>898</width>
-            <height>828</height>
-           </rect>
-          </property>
-         </widget>
-        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Update the results tab to use QScrollArea instead of QTreeView that used a delegate to render search item results and caused QGIS to crash when painting pixmap.

Now user can search and see results with thumbnail and load the COG item assets into QGIS.

Screenshot
![search_results_fixed](https://user-images.githubusercontent.com/2663775/146544772-e1ca1a7c-530e-40fd-8bfb-145986df7e63.gif)

