### PR TITLE
Support for loading item footprints when they are available

### DIFF
--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -60,6 +60,8 @@ class Client(BaseClient):
                 assets=assets
 
             )
+            if item.geometry:
+                item_result.geometry = item.geometry
             items.append(item_result)
 
         self.items_received.emit(items, pagination)

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -190,7 +190,7 @@ class Item:
     type: ResourceType = None
     stac_version: str = None
     stac_extensions: typing.List[str] = None
-    geometry: ResourceGeometry = None
+    geometry: typing.Optional[dict] = None
     bbox: typing.List[float] = None
     properties: ResourceProperties = None
     links: typing.List[ResourceLink] = None

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">

--- a/src/qgis_stac/ui/result_item_widget.ui
+++ b/src/qgis_stac/ui/result_item_widget.ui
@@ -146,7 +146,7 @@
           <item>
            <widget class="QToolButton" name="footprint_box">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open resource in Browser&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Add item footprint as a layer</string>
             </property>
             <property name="text">
              <string>Add footprint</string>
@@ -155,6 +155,9 @@
           </item>
           <item>
            <widget class="QComboBox" name="assets_load_box">
+            <property name="toolTip">
+             <string>Add item assets as layers</string>
+            </property>
             <item>
              <property name="text">
               <string>Add assets as layers</string>
@@ -164,6 +167,9 @@
           </item>
           <item>
            <widget class="QComboBox" name="assets_download_box">
+            <property name="toolTip">
+             <string>Download item assets</string>
+            </property>
             <item>
              <property name="text">
               <string>Download assets</string>
@@ -195,7 +201,7 @@
            <enum>QFrame::StyledPanel</enum>
           </property>
           <property name="text">
-           <string>Thumbnail</string>
+           <string>No Thumbnail</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>


### PR DESCRIPTION
Follow up PR from https://github.com/stac-utils/qgis-stac-plugin/pull/68
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/57

Enables loading item footprints inside QGIS as map layers.

Screenshot
![footprints](https://user-images.githubusercontent.com/2663775/146924457-4101f362-a9ee-475d-9697-4a036f5bcbff.gif)

