### PR TITLE
Plugin UI tweaks

### DIFF
--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -31,7 +31,8 @@ class Client(BaseClient):
         """
         items = []
         properties = None
-        for item in items_response.items:
+        items_list = items_response.items if items_response else []
+        for item in items_list:
             try:
                 item_datetime = datetime.datetime.strptime(
                     item.properties.get("datetime"),

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -1,4 +1,3 @@
-
 import typing
 
 from qgis.PyQt import (
@@ -42,12 +41,12 @@ class ContentFetcherTask(QgsTask):
     pagination = None
 
     def __init__(
-        self,
-        url: str,
-        search_params: ItemSearch,
-        resource_type: ResourceType,
-        response_handler: typing.Callable = None,
-        error_handler: typing.Callable = None,
+            self,
+            url: str,
+            search_params: ItemSearch,
+            resource_type: ResourceType,
+            response_handler: typing.Callable = None,
+            error_handler: typing.Callable = None,
     ):
         super().__init__()
         self.url = url
@@ -71,9 +70,21 @@ class ContentFetcherTask(QgsTask):
                     **self.search_params.params()
                 )
                 self.pagination = ResourcePagination()
-                for i, collection in enumerate(response.get_item_collections()):
-                    if self.search_params.page == (i + 1):
-                        self.response = collection
+
+                count = 1
+                items_generator = response.get_item_collections()
+                prev_collection = None
+                while True:
+                    try:
+                        collection = next(items_generator)
+                        prev_collection = collection
+                        if self.search_params.page == count:
+                            self.response = collection
+                            break
+                        count += 1
+                    except StopIteration:
+                        self.pagination.total_pages = count
+                        self.response = prev_collection
                         break
 
             elif self.resource_type == \

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -431,7 +431,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             if len(results) > 0:
                 self.result_items_la.setText(
                     tr(
-                        "Displaying page {} of results, with {} item(s)"
+                        "Displaying page {} of results, {} item(s)"
                     ).format(
                         self.page,
                         len(results)

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -479,8 +479,14 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             )
             layout.addWidget(search_result_widget)
             layout.setAlignment(search_result_widget, QtCore.Qt.AlignTop)
+        vertical_spacer = QtWidgets.QSpacerItem(
+            20,
+            40,
+            QtWidgets.QSizePolicy.Minimum,
+            QtWidgets.QSizePolicy.Expanding
+        )
+        layout.addItem(vertical_spacer)
         scroll_container.setLayout(layout)
-        self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
         self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area.setWidget(scroll_container)

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -128,8 +128,8 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.populate_sorting_field()
 
         download_folder = settings_manager.get_value(
-                Settings.DOWNLOAD_FOLDER
-            )
+            Settings.DOWNLOAD_FOLDER
+        )
         self.download_folder_btn.setFilePath(
             download_folder
         ) if download_folder else None
@@ -256,14 +256,19 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         search operation.
         """
         self.search_type = ResourceType.FEATURE
+        use_start_date = self.date_filter_group.isChecked() and \
+                         not self.start_dte.dateTime().isNull()
+        use_end_date = self.date_filter_group.isChecked() and \
+                       not self.end_dte.dateTime().isNull()
         start_dte = self.start_dte.dateTime() \
-            if not self.start_dte.dateTime().isNull() else None
+            if use_start_date else None
         end_dte = self.end_dte.dateTime() \
-            if not self.end_dte.dateTime().isNull() else None
+            if use_end_date else None
 
         collections = self.get_selected_collections()
         page_size = settings_manager.get_current_connection().page_size
-        spatial_extent = self.extent_box.outputExtent()
+        spatial_extent = self.extent_box.outputExtent() \
+            if self.extent_box.isChecked() else None
         self.api_client.get_items(
             ItemSearch(
                 collections=collections,

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -77,6 +77,9 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.prev_btn.clicked.connect(
             self.previous_items
         )
+        self.clear_results_btn.clicked.connect(
+            self.clear_search_results
+        )
 
         self.fetch_collections_btn.clicked.connect(
             self.search_collections
@@ -476,6 +479,11 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area.setWidget(scroll_container)
+
+    def clear_search_results(self):
+        """ Clear current search results from the UI"""
+        self.scroll_area.setWidget(QtWidgets.QWidget())
+        self.result_items_la.clear()
 
     def filter_changed(self, filter_text):
         """

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -410,40 +410,42 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         if self.search_type == ResourceType.COLLECTION:
             self.model.removeRows(0, self.model.rowCount())
             self.result_collections_la.setText(
-                tr("Found {} STAC collection(s)").format(len(results))
+                tr("Found {} STAC collection(s)").format(
+                    len(results)
+                )
             )
             self.current_collections = results
             self.load_collections(results)
             self.save_filters()
 
         elif self.search_type == ResourceType.FEATURE:
-            if pagination.total_items != 0:
-                self.result_items_la.setText(
-                    tr(
-                        "Page {} out {} pages, "
-                        "total {} STAC item(s) found.").format(
-                        self.page,
-                        pagination.total_pages,
-                        pagination.total_items
-                    )
-                )
-            self.total_pages = pagination.total_pages
-            if len(results) > 0:
-                self.result_items_la.setText(
-                    tr(
-                        "Displaying page {} of results, {} item(s)"
-                    ).format(
-                        self.page,
-                        len(results)
-                    )
-                )
-                self.populate_results(results)
+
+            if pagination.total_pages > 0:
+                if self.page > 1:
+                    self.page -= 1
+                self.next_btn.setEnabled(False)
             else:
-                self.result_items_la.setText(
-                    tr(
-                        "No items were found"
+                if len(results) > 0:
+                    self.result_items_la.setText(
+                        tr(
+                            "Displaying page {} of results, {} item(s)"
+                        ).format(
+                            self.page,
+                            len(results)
+                        )
                     )
-                )
+                    self.populate_results(results)
+                else:
+                    self.clear_search_results()
+                    if self.page > 1:
+                        self.page -= 1
+                    self.result_items_la.setText(
+                        tr(
+                            "No items were found"
+                        )
+                    )
+                self.next_btn.setEnabled(len(results) > 0)
+                self.prev_btn.setEnabled(self.page > 1)
             self.container.setCurrentIndex(1)
 
         else:

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -420,7 +420,22 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
                     )
                 )
             self.total_pages = pagination.total_pages
-            self.populate_results(results)
+            if len(results) > 0:
+                self.result_items_la.setText(
+                    tr(
+                        "Displaying page {} of results, with {} item(s)"
+                    ).format(
+                        self.page,
+                        len(results)
+                    )
+                )
+                self.populate_results(results)
+            else:
+                self.result_items_la.setText(
+                    tr(
+                        "No items were found"
+                    )
+                )
             self.container.setCurrentIndex(1)
 
         else:
@@ -439,6 +454,11 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.search_completed.emit()
 
     def populate_results(self, results):
+        """ Add the found results into the widget scroll area
+
+        :param results: List of items results
+        :type results: list
+        """
         scroll_container = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(1, 1, 1, 1)

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">
@@ -600,9 +600,9 @@
           <enum>QLayout::SetMinimumSize</enum>
          </property>
          <item>
-          <widget class="QPushButton" name="clear_results">
+          <widget class="QPushButton" name="clear_results_btn">
            <property name="toolTip">
-            <string>Remove current results</string>
+            <string>Clear the current results</string>
            </property>
            <property name="text">
             <string>Clear</string>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -241,7 +241,7 @@
           <string>Filter by date</string>
          </property>
          <property name="checkable">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <property name="checked">
           <bool>false</bool>
@@ -317,7 +317,7 @@
           <enum>Qt::LeftToRight</enum>
          </property>
          <property name="title">
-          <string>Extent (curent layer)</string>
+          <string>Extent (current: none)</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -326,6 +326,9 @@
           <bool>true</bool>
          </property>
          <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
           <bool>false</bool>
          </property>
          <property name="collapsed">

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">
@@ -554,6 +554,30 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QLabel" name="result_items_la">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>37</width>
+             <height>17</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QScrollArea" name="scroll_area">
          <property name="widgetResizable">
           <bool>true</bool>
@@ -564,17 +588,10 @@
             <x>0</x>
             <y>0</y>
             <width>898</width>
-            <height>737</height>
+            <height>735</height>
            </rect>
           </property>
          </widget>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="result_items_la">
-         <property name="text">
-          <string/>
-         </property>
         </widget>
        </item>
        <item>
@@ -582,6 +599,16 @@
          <property name="sizeConstraint">
           <enum>QLayout::SetMinimumSize</enum>
          </property>
+         <item>
+          <widget class="QPushButton" name="clear_results">
+           <property name="toolTip">
+            <string>Remove current results</string>
+           </property>
+           <property name="text">
+            <string>Clear</string>
+           </property>
+          </widget>
+         </item>
          <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">


### PR DESCRIPTION
Updates and fixes on the plugin UI, including

- [x] Layout fix on the search result area when result items were small in numbers
- [x] Added a message about which results page  and if there were any items found when searching has finished
- [x] Enable toggles on the date group box and the spatial filter box, now if these boxes are unchecked then their respective inputs wont be used in searching.
- [x] Added a clear button, that will be used to remove the search results items from the results tab,
- [x] Implemented a check of the next and previous buttons to be disabled when there is no corresponding page to retrieve.

cc @mmcfarland 