### PR TITLE
Initialize default connections with empty collections

### DIFF
--- a/src/qgis_stac/utils.py
+++ b/src/qgis_stac/utils.py
@@ -79,6 +79,7 @@ def config_defaults_catalogs():
                 name=catalog['name'],
                 url=catalog['url'],
                 page_size=5,
+                collections=[],
                 created_date=datetime.datetime.now(),
                 auth_config=None,
             )


### PR DESCRIPTION
When setting the default STAC APIs we now config them with empty collections.
Screenshot
![image](https://user-images.githubusercontent.com/2663775/147162181-45f327c4-8b09-42c4-aae8-a58b9b53badf.png)

