### PR TITLE
Set capabilities for plugin default connections

### DIFF
--- a/src/qgis_stac/conf.py
+++ b/src/qgis_stac/conf.py
@@ -74,8 +74,6 @@ class ConnectionSettings:
         auth_cfg = None
         capability = None
         try:
-
-            auth_cfg = settings.value("auth_config").strip()
             collections = settings_manager.get_collections(
                 uuid.UUID(identifier)
             )
@@ -86,6 +84,7 @@ class ConnectionSettings:
                 settings.value("created_date"),
                 "%Y-%m-%dT%H:%M:%S.%fZ"
             )
+            auth_cfg = settings.value("auth_config").strip()
         except AttributeError:
             created_date = datetime.datetime.now()
 

--- a/src/qgis_stac/definitions/catalog.py
+++ b/src/qgis_stac/definitions/catalog.py
@@ -3,35 +3,42 @@
     Definitions for all pre-installed STAC API catalog connections
 """
 
+from ..api.models import ApiCapability
+
 CATALOGS = [
     {
         "id": "07e3e9dd-cbad-4cf6-8336-424b88abf8f3",
         "name": "Microsoft Planetary Computer STAC API",
         "url": "https://planetarycomputer.microsoft.com/api/stac/v1",
         "selected": True,
+        "capability": ApiCapability.SUPPORT_SAS_TOKEN.value
     },
     {
         "id": "d74817bf-da1f-44d7-a464-b87d4009c8a3",
         "name": "Earth Search",
         "url": "https://earth-search.aws.element84.com/v0",
         "selected": False,
+        "capability": None,
     },
     {
         "id": "aff201e0-58aa-483d-9e87-090c8baecd3c",
         "name": "Digital Earth Africa",
         "url": "https://explorer.digitalearth.africa/stac/",
         "selected": False,
+        "capability": None,
     },
     {
         "id": "98c95473-9f32-4947-83b2-acc8bbf71f36",
         "name": "Radiant MLHub",
         "url": "https://api.radiant.earth/mlhub/v1/",
         "selected": False,
+        "capability": None,
     },
     {
         "id": "17a79ce2-9a61-457d-926f-03d37c0606b6",
         "name": "NASA CMR STAC",
         "url": "https://cmr.earthdata.nasa.gov/stac",
         "selected": False,
+        "capability": None,
     }
 ]

--- a/src/qgis_stac/utils.py
+++ b/src/qgis_stac/utils.py
@@ -10,6 +10,8 @@ import datetime
 
 from qgis.PyQt import QtCore
 from qgis.core import Qgis, QgsMessageLog
+
+from .api.models import ApiCapability
 from .conf import (
     ConnectionSettings,
     settings_manager
@@ -71,6 +73,9 @@ def config_defaults_catalogs():
 
     for catalog in CATALOGS:
         connection_id = uuid.UUID(catalog['id'])
+
+        capability = ApiCapability(catalog["capability"]) \
+            if catalog["capability"] else None
         if not settings_manager.is_connection(
                 connection_id
         ):
@@ -80,6 +85,7 @@ def config_defaults_catalogs():
                 url=catalog['url'],
                 page_size=5,
                 collections=[],
+                capability=capability,
                 created_date=datetime.datetime.now(),
                 auth_config=None,
             )


### PR DESCRIPTION
Follow up PR from https://github.com/stac-utils/qgis-stac-plugin/pull/79
Added  and set value for the capability property for each of the auto configured plugin connections.
These connections are created when installing the plugin for the first time, see https://github.com/stac-utils/qgis-stac-plugin/pull/26