### PR TITLE
Update content fetcher logic when fetching collections

### DIFF
--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -106,19 +106,12 @@ class Client(BaseClient):
         :param pagination: Collection results pagination details
         :type pagination: ResourcePagination
         """
-        collections = []
-        for collection in collections_response:
-            collection_result = Collection(
-                id=collection.id,
-                title=collection.title
-            )
-            collections.append(collection_result)
 
         # TODO query filter pagination results from the
         # response
         pagination = ResourcePagination()
 
-        self.collections_received.emit(collections, pagination)
+        self.collections_received.emit(collections_response, pagination)
 
     def handle_conformance(
             self,

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -323,7 +323,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             STAC API connection.
         """
         self.search_type = ResourceType.COLLECTION
-        self.current_progress_message = tr("Searching for collections...")
+        self.current_progress_message = tr("Fetching collections...")
 
         self.api_client.get_collections()
         self.search_started.emit()


### PR DESCRIPTION
When fetching collections, we should be returning list of collections from the network content fetcher to the plugin UI, and not a Collection generator.
We need to also make sure we prepare the collection list in a the background task as each iteration inside the Collection generator makes a network request to the API.

