### PR TITLE
Load the whole STAC item as a footprint

### DIFF
--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -1,5 +1,3 @@
-
-
 from .base import BaseClient
 from .models import (
     ResourcePagination,

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -20,6 +20,8 @@ from qgis.PyQt import (
 
 from qgis.core import QgsRectangle
 
+from ..lib.pystac.item import Item as STACObject
+
 
 @dataclasses.dataclass
 class ResourcePagination:
@@ -211,6 +213,7 @@ class Item:
     links: typing.List[ResourceLink] = None
     assets: typing.Dict[str, ResourceAsset] = None
     collection: str = None
+    stac_object: STACObject = None
 
 
 @dataclasses.dataclass

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -201,7 +201,8 @@ class ContentFetcherTask(QgsTask):
                 id=item.id,
                 properties=properties,
                 collection=item.collection_id,
-                assets=assets
+                assets=assets,
+                stac_object=item,
 
             )
             if item.geometry:

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -124,7 +124,7 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
             'selection-color: white;'
         )
 
-        self.footprint_box.setEnabled(self.item.geometry is not None)
+        self.footprint_box.setEnabled(self.item.stac_object is not None)
         self.footprint_box.clicked.connect(self.add_footprint)
 
     def add_footprint(self):
@@ -135,7 +135,7 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
             delete=False
         )
         layer_name = f"{self.item.id}_footprint"
-        json.dump(self.item.geometry, layer_file)
+        json.dump(self.item.stac_object.to_dict(), layer_file)
 
         layer_file.flush()
 


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/74

Uses the API pystac Item as a footprint instead of adding its geometry only.

Screenshot
![use_item_as_footprint](https://user-images.githubusercontent.com/2663775/147881873-73a7dd4d-0e48-4560-afc7-d588c5873ed7.gif)

cc @mmcfarland 