### PR TITLE
Fallback to asset key if asset title is not available

### DIFF
--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -189,9 +189,10 @@ class ContentFetcherTask(QgsTask):
                 )
             assets = []
             for key, asset in item.assets.items():
+                title = asset.title if asset.title else key
                 item_asset = ResourceAsset(
                     href=asset.href,
-                    title=asset.title,
+                    title=title,
                     description=asset.description,
                     type=asset.media_type,
                     roles=asset.roles or []


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/73
Some of the STAC item assets dont have a title, we are defaulting to use their dictionary key as the asset title.