### PR TITLE
Update message level and removed unused connection buttons

### DIFF
--- a/src/qgis_stac/gui/connection_dialog.py
+++ b/src/qgis_stac/gui/connection_dialog.py
@@ -364,5 +364,5 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         else:
             self.show_message(
                 tr("Connection is not a valid STAC API"),
-                level=Qgis.Info)
+                level=Qgis.Critical)
         self.update_connection_inputs(True)

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -105,32 +105,6 @@
               </property>
              </spacer>
             </item>
-            <item>
-             <widget class="QPushButton" name="load_connection_btn">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="toolTip">
-               <string>Load connections from file</string>
-              </property>
-              <property name="text">
-               <string>Load</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="save_connection_btn">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="toolTip">
-               <string>Save connections to file</string>
-              </property>
-              <property name="text">
-               <string>Save</string>
-              </property>
-             </widget>
-            </item>
            </layout>
           </item>
          </layout>


### PR DESCRIPTION
Updated the connection invalid connection message level to critical when testing connections and removed load and save connections buttons.