### PR TITLE
Assets download and loading updates

### DIFF
--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -67,6 +67,6 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
         self.download_btn.clicked.connect(download_asset)
 
         if self.asset.type not in layer_types:
-            self.load_btn.setTooltip(
+            self.load_btn.setToolTip(
                 tr("Asset cannot be loaded as layer in QGIS")
             )

--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -64,5 +64,5 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
 
         if self.asset.type not in layer_types:
             self.load_btn.setToolTip(
-                tr("Asset cannot be loaded as layer in QGIS")
+                tr("Asset cannot be loaded as a map layer in QGIS")
             )

--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+    Result item widget, used as a template for each search result item.
+"""
+
+import os
+
+import json
+import tempfile
+import datetime
+
+from functools import partial
+
+from qgis.PyQt import (
+    QtGui,
+    QtCore,
+    QtWidgets,
+    QtNetwork
+)
+from qgis.PyQt.uic import loadUiType
+
+from ..utils import log, tr
+
+WidgetUi, _ = loadUiType(
+    os.path.join(os.path.dirname(__file__), "../ui/asset_widget.ui")
+)
+
+
+class AssetWidget(QtWidgets.QWidget, WidgetUi):
+    """ Widget that provide UI for asset details,
+    assets loading and downloading functionalities
+    """
+
+    def __init__(
+        self,
+        asset,
+        asset_dialog,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.asset = asset
+        self.asset_dialog = asset_dialog
+
+        self.initialize_ui()
+
+    def initialize_ui(self):
+        """ Populate UI inputs when loading the widget"""
+
+        layer_types = [
+            "image/tiff; "
+            "application=geotiff; "
+            "profile=cloud-optimized"
+        ]
+
+        self.title_la.setText(self.asset.title)
+        load_asset = partial(
+            self.asset_dialog.load_asset,
+            self.asset
+        )
+        download_asset = partial(
+            self.asset_dialog.download_asset,
+            self.asset
+        )
+        self.load_btn.setEnabled(self.asset.type in layer_types)
+        self.load_btn.clicked.connect(load_asset)
+        self.download_btn.clicked.connect(download_asset)
+
+        if self.asset.type not in layer_types:
+            self.load_btn.setTooltip(
+                tr("Asset cannot be loaded as layer in QGIS")
+            )

--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-    Result item widget, used as a template for each search result item.
+    Asset item widget, used as a template for each item asset.
 """
 
 import os
-
-import json
-import tempfile
-import datetime
 
 from functools import partial
 
@@ -19,7 +15,7 @@ from qgis.PyQt import (
 )
 from qgis.PyQt.uic import loadUiType
 
-from ..utils import log, tr
+from ..utils import tr
 
 WidgetUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/asset_widget.ui")

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -1,0 +1,375 @@
+import os
+from functools import partial
+
+from qgis import processing
+
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsMapLayer,
+    QgsNetworkContentFetcherTask,
+    QgsProject,
+    QgsRasterLayer,
+    QgsTask,
+    QgsVectorLayer,
+
+)
+
+from ..resources import *
+
+from ..api.models import (
+    AssetLayerType,
+    AssetRoles,
+    Settings,
+)
+
+from qgis.PyQt import QtCore, QtGui, QtWidgets
+
+from qgis.core import Qgis
+from qgis.gui import QgsMessageBar
+
+from qgis.PyQt.uic import loadUiType
+
+from ..conf import (
+    ConnectionSettings,
+    settings_manager
+)
+
+from .asset_widget import AssetWidget
+
+from ..utils import log, tr
+
+DialogUi, _ = loadUiType(
+    os.path.join(os.path.dirname(__file__), "../ui/item_assets_widget.ui")
+)
+
+
+class AssetsDialog(QtWidgets.QDialog, DialogUi):
+    """ Dialog for adding and downloading STAC Item assets"""
+
+    def __init__(
+            self,
+            assets,
+            main_widget,
+            connection=None
+    ):
+        """ Constructor
+
+        :param assets: List of item assets
+        :type assets: list
+
+        :param connection: Connection settings
+        :type connection: ConnectionSettings
+        """
+        super().__init__()
+        self.setupUi(self)
+        self.connection = connection
+        self.assets = assets
+        self.main_widget = main_widget
+        self.cog_string = '/vsicurl/'
+
+        # prepare model for the assets tree view
+        self.model = QtGui.QStandardItemModel()
+        self.proxy_model = QtCore.QSortFilterProxyModel()
+        self.proxy_model.setSourceModel(self.model)
+        self.proxy_model.setDynamicSortFilter(True)
+        self.proxy_model.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        self.proxy_model.setSortCaseSensitivity(QtCore.Qt.CaseInsensitive)
+
+        self.grid_layout = QtWidgets.QGridLayout()
+        self.message_bar = QgsMessageBar()
+        self.progress_bar = QtWidgets.QProgressBar()
+
+        self.prepare_message_bar()
+        self.prepare_assets()
+
+    def prepare_assets(self):
+        """ Loads the dialog list of assets into the assets
+        scroll view
+        """
+        self.title.setText(tr("Item has {} assets").format(len(self.assets)))
+        scroll_container = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(1, 1, 1, 1)
+        layout.setSpacing(1)
+        for asset in self.assets:
+            asset_widget = AssetWidget(asset, self)
+
+            layout.addWidget(asset_widget)
+            layout.setAlignment(asset_widget, QtCore.Qt.AlignTop)
+        vertical_spacer = QtWidgets.QSpacerItem(
+            20,
+            40,
+            QtWidgets.QSizePolicy.Minimum,
+            QtWidgets.QSizePolicy.Expanding
+        )
+        layout.addItem(vertical_spacer)
+        scroll_container.setLayout(layout)
+        self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setWidget(scroll_container)
+
+    def update_inputs(self, enabled):
+        """ Updates the inputs widgets state in the main search item widget.
+
+        :param enabled: Whether to enable the inputs or disable them.
+        :type enabled: bool
+        """
+        self.scroll_area.setEnabled(enabled)
+
+    def download_asset(self, asset):
+        """ Download asset into directory defined in the plugin settings.
+
+        :param index: Index of the selected combo box item
+        :type index: int
+        """
+        download_folder = settings_manager.get_value(
+            Settings.DOWNLOAD_FOLDER
+        )
+        url = asset.href
+        output = os.path.join(
+            download_folder, asset.title
+        ) if download_folder else None
+        params = {'URL': url, 'OUTPUT': output} \
+            if download_folder else \
+            {'URL': url}
+        try:
+            self.main_widget.show_message(
+                tr("Download for file {} to {} has started."
+                   "View Processing log for the download progress"
+                   ).format(
+                    asset.title,
+                    download_folder
+                ),
+                level=Qgis.Info
+            )
+            processing.run("qgis:filedownloader", params)
+        except Exception as e:
+            self.main_widget.show_message("Error in downloading file")
+
+    def load_asset(self, asset):
+        """ Loads asset into QGIS.
+            Checks if the asset type is a loadable layer inside QGIS.
+
+        :param index: Index of the selected combo box item
+        :type index: int
+        """
+
+        assert_type = asset.type
+        layer_type = QgsMapLayer.RasterLayer
+
+        if AssetLayerType.COG.value in assert_type:
+            asset_href = f"{self.cog_string}" \
+                         f"{asset.href}"
+        else:
+            asset_href = f"{asset.href}"
+        asset_name = asset.title
+
+        self.update_inputs(False)
+        self.layer_loader = LayerLoader(
+            asset_href,
+            asset_name,
+            layer_type
+        )
+
+        # Using signal approach to detect the results of the layer loader
+        # task as the callback function approach doesn't make the task
+        # to recall the assigned callbacks in the provided context.
+        self.layer_loader.taskCompleted.connect(self.add_layer)
+        self.layer_loader.progressChanged.connect(self.main_widget.update_progress_bar)
+        self.layer_loader.taskTerminated.connect(self.layer_loader_terminated)
+
+        QgsApplication.taskManager().addTask(self.layer_loader)
+
+        self.main_widget.show_progress(
+            f"Adding asset \"{asset_name}\" into QGIS",
+            minimum=0,
+            maximum=100,
+        )
+        self.main_widget.update_progress_bar(0)
+        log(tr("Started adding asset into QGIS"))
+
+    def add_layer(self):
+        """ Adds layer into the current QGIS project.
+            For the layer to be added successfully, the task for loading
+            layer need to exist and the corresponding layer need to be
+            available.
+        """
+        if self.layer_loader and self.layer_loader.layer:
+            layer = self.layer_loader.layer
+            QgsProject.instance().addMapLayer(layer)
+
+            message = tr("Sucessfully added asset as a map layer")
+            level = Qgis.Info
+        elif self.layer_loader and self.layer_loader.error:
+            message = self.layer_loader.error
+            level = Qgis.Critical
+        else:
+            message = tr("Problem fetching asset and loading it, into QGIS")
+            level = Qgis.Critical
+
+        self.update_inputs(True)
+        log(message)
+        self.main_widget.show_message(
+            message,
+            level=level
+        )
+
+    def layer_loader_terminated(self):
+        """ Shows message to user when layer loading task has been terminated"""
+        message = tr("QGIS background task for loading assets was terminated.")
+        self.update_inputs(True)
+        log(message)
+        self.main_widget.show_message(
+            message,
+            level=Qgis.Critical
+        )
+
+    def handle_layer_error(self, message):
+        """ Handles the error message from the layer loading task
+
+        :param message: The error message
+        :type message: str
+        """
+        self.update_inputs(True)
+        log(message)
+        self.main_widget.show_message(
+            message
+        )
+
+    def prepare_message_bar(self):
+        """ Initializes the widget message bar settings"""
+        self.message_bar.setSizePolicy(
+            QtWidgets.QSizePolicy.Minimum,
+            QtWidgets.QSizePolicy.Fixed
+        )
+        self.grid_layout.addWidget(
+            self.title,
+            0, 0, 1, 1
+        )
+        self.grid_layout.addWidget(
+            self.message_bar,
+            0, 0, 1, 1,
+            alignment=QtCore.Qt.AlignTop
+        )
+        self.layout().insertLayout(0, self.grid_layout)
+
+    def show_message(
+            self,
+            message,
+            level=Qgis.Warning
+    ):
+        """ Shows message on the main widget message bar
+
+        :param message: Message text
+        :type message: str
+
+        :param level: Message level type
+        :type level: Qgis.MessageLevel
+        """
+        self.message_bar.clearWidgets()
+        self.message_bar.pushMessage(message, level=level)
+
+    def show_progress(
+            self,
+            message,
+            minimum=0,
+            maximum=0,
+            progress_bar=True):
+        """ Shows the progress message on the main widget message bar
+
+        :param message: Progress message
+        :type message: str
+
+        :param minimum: Minimum value that can be set on the progress bar
+        :type minimum: int
+
+        :param maximum: Maximum value that can be set on the progress bar
+        :type maximum: int
+
+        :param progress_bar: Whether to show progress bar status
+        :type progress_bar: bool
+        """
+        self.message_bar.clearWidgets()
+        message_bar_item = self.message_bar.createMessage(message)
+        try:
+            self.progress_bar.isEnabled()
+        except RuntimeError as er:
+            self.progress_bar = QtWidgets.QProgressBar()
+        self.progress_bar.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
+        if progress_bar:
+            self.progress_bar.setMinimum(minimum)
+            self.progress_bar.setMaximum(maximum)
+        else:
+            self.progress_bar.setMaximum(0)
+        message_bar_item.layout().addWidget(self.progress_bar)
+        self.message_bar.pushWidget(message_bar_item, Qgis.Info)
+
+
+class LayerLoader(QgsTask):
+    """ Prepares and loads items as assets inside QGIS as layers."""
+    def __init__(
+        self,
+        layer_uri,
+        layer_name,
+        layer_type
+    ):
+
+        super().__init__()
+        self.layer_uri = layer_uri
+        self.layer_name = layer_name
+        self.layer_type = layer_type
+        self.error = None
+        self.layer = None
+
+    def run(self):
+        """ Operates the main layers loading logic
+        """
+        log(
+            tr("Fetching layers in a background task.")
+        )
+        if self.layer_type is QgsMapLayer.RasterLayer:
+            self.layer = QgsRasterLayer(
+                self.layer_uri,
+                self.layer_name
+            )
+            return self.layer.isValid()
+        elif self.layer_type is QgsMapLayer.VectorLayer:
+            self.layer = QgsVectorLayer(
+                self.layer_uri,
+                self.layer_name,
+                AssetLayerType.VECTOR.value
+            )
+            return self.layer.isValid()
+        else:
+            raise NotImplementedError
+
+        return False
+
+    def finished(self, result: bool):
+        """ Calls the handler responsible for adding the
+         layer into QGIS project.
+
+        :param result: Whether the run() operation finished successfully
+        :type result: bool
+        """
+        if result and self.layer:
+            log(
+                f"Fetched layer with URI"
+                f"{self.layer_uri} "
+            )
+            # Due to the way QGIS is handling layers sharing between tasks and
+            # the main thread, sending the layer to the main thread
+            # without cloning it can lead to unpredicted crashes,
+            # hence we clone the layer before storing it, so it can
+            # be used in the main thread.
+            self.layer = self.layer.clone()
+        else:
+            self.error = tr(
+                f"Couldn't load layer "
+                f"{self.layer_uri},"
+                f"error {self.layer.dataProvider().error()}"
+            )
+            log(
+                self.error
+            )

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -87,7 +87,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         """ Loads the dialog list of assets into the assets
         scroll view
         """
-        self.title.setText(tr("Item has {} assets").format(len(self.assets)))
+        self.title.setText(tr("{} asset(s) available").format(len(self.assets)))
         scroll_container = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(1, 1, 1, 1)

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -29,7 +29,6 @@ from ..api.models import (
 from qgis.PyQt import QtCore, QtGui, QtWidgets
 
 from qgis.core import Qgis
-from qgis.gui import QgsMessageBar
 
 from qgis.PyQt.uic import loadUiType
 

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -68,11 +68,6 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         self.main_widget = main_widget
         self.cog_string = '/vsicurl/'
 
-        self.grid_layout = QtWidgets.QGridLayout()
-        self.message_bar = QgsMessageBar()
-        self.progress_bar = QtWidgets.QProgressBar()
-
-        self.prepare_message_bar()
         self.prepare_assets()
 
     def prepare_assets(self):

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -435,6 +435,7 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         :param enabled: Whether to enable the inputs
         :type enabled: bool
         """
+        self.connections_group.setEnabled(enabled)
         self.collections_group.setEnabled(enabled)
         self.date_filter_group.setEnabled(enabled)
         self.extent_box.setEnabled(enabled)

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -43,7 +43,7 @@ WidgetUi, _ = loadUiType(
 )
 
 
-class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
+class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
     """ Main plugin widget that contains tabs for search, results and settings
     functionalities"""
 

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -39,10 +39,9 @@ from ..utils import log, tr
 from ..api.models import (
     AssetLayerType,
     AssetRoles,
-    Settings,
 )
 
-from ..conf import settings_manager
+from .assets_dialog import AssetsDialog
 
 
 WidgetUi, _ = loadUiType(
@@ -70,7 +69,6 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         self.title_la.setText(item.id)
         self.collection_name.setText(item.collection)
         self.thumbnail_url = None
-        self.cog_string = '/vsicurl/'
         self.date_format = "%Y-%m-%dT%H:%M:%S"
         self.main_widget = main_widget
         self.layer_loader = None
@@ -90,42 +88,24 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
             datetime_str
         )
 
-        layer_types = [
-            "image/tiff; "
-            "application=geotiff; "
-            "profile=cloud-optimized"
-        ]
-
         for asset in self.item.assets:
-            self.assets_download_box.addItem(
-                asset.title,
-                asset.href
-            )
-            if asset.type in layer_types:
-                self.assets_load_box.addItem(
-                    asset.title,
-                    {
-                        "href": asset.href,
-                        "type": asset.type,
-                    }
-                )
             if AssetRoles.THUMBNAIL.value in asset.roles:
                 self.thumbnail_url = asset.href
 
-        self.assets_load_box.activated.connect(self.load_asset)
-        self.assets_download_box.activated.connect(self.download_asset)
-        # make sure the palette highlight colors are the same
-        self.assets_load_box.setStyleSheet(
-            'selection-background-color: rgb(32, 100, 189);'
-            'selection-color: white;'
-        )
-        self.assets_download_box.setStyleSheet(
-            'selection-background-color: rgb(32, 100, 189);'
-            'selection-color: white;'
-        )
+        self.view_assets_btn.setEnabled(self.item.assets is not None)
+        self.view_assets_btn.clicked.connect(self.open_assets_dialog)
 
         self.footprint_box.setEnabled(self.item.stac_object is not None)
         self.footprint_box.clicked.connect(self.add_footprint)
+
+    def open_assets_dialog(self):
+        """  Opens the assets dialog
+        """
+        assets_dialog = AssetsDialog(
+            self.item.assets,
+            main_widget=self.main_widget
+        )
+        assets_dialog.exec_()
 
     def add_footprint(self):
         """ Adds the item footprint inside QGIS as a map layer"""
@@ -159,140 +139,6 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
                 ),
                 level=Qgis.Critical
             )
-
-    def update_inputs(self, enabled):
-        """ Updates the inputs widgets state in the main search item widget.
-
-        :param enabled: Whether to enable the inputs or disable them.
-        :type enabled: bool
-        """
-        self.assets_load_box.setEnabled(enabled)
-        self.assets_download_box.setEnabled(enabled)
-        self.footprint_box.setEnabled(enabled)
-
-    def download_asset(self, index):
-        """ Download asset into directory defined in the plugin settings.
-
-        :param index: Index of the selected combo box item
-        :type index: int
-        """
-        if self.assets_download_box.count() < 1 or index < 1:
-            return
-        download_folder = settings_manager.get_value(
-            Settings.DOWNLOAD_FOLDER
-        )
-        url = self.assets_download_box.itemData(index)
-        output = os.path.join(
-            download_folder, self.assets_download_box.currentText()
-        ) if download_folder else None
-        params = {'URL': url, 'OUTPUT': output} \
-            if download_folder else \
-            {'URL': url}
-        try:
-            self.main_widget.show_message(
-                tr("Download for file {} to {} has started."
-                   "View Processing log for the download progress"
-                   ).format(
-                    self.assets_download_box.currentText(),
-                    download_folder
-                ),
-                level=Qgis.Info
-            )
-            processing.run("qgis:filedownloader", params)
-        except Exception as e:
-            self.main_widget.show_message("Error in downloading file")
-
-    def load_asset(self, index):
-        """ Loads asset into QGIS.
-            Checks if the asset type is a loadable layer inside QGIS.
-
-        :param index: Index of the selected combo box item
-        :type index: int
-        """
-
-        if self.assets_load_box.count() < 1 or index < 1:
-            return
-        assert_type = self.assets_load_box.itemData(index)['type']
-        layer_type = QgsMapLayer.RasterLayer
-
-        if AssetLayerType.COG.value in assert_type:
-            asset_href = f"{self.cog_string}" \
-                         f"{self.assets_load_box.itemData(index)['href']}"
-        else:
-            asset_href = f"{self.assets_load_box.itemData(index)['href']}"
-        asset_name = self.assets_load_box.itemText(index)
-
-        self.update_inputs(False)
-        self.layer_loader = LayerLoader(
-            asset_href,
-            asset_name,
-            layer_type
-        )
-
-        # Using signal approach to detect the results of the layer loader
-        # task as the callback function approach doesn't make the task
-        # to recall the assigned callbacks in the provided context.
-        self.layer_loader.taskCompleted.connect(self.add_layer)
-        self.layer_loader.progressChanged.connect(self.main_widget.update_progress_bar)
-        self.layer_loader.taskTerminated.connect(self.layer_loader_terminated)
-
-        QgsApplication.taskManager().addTask(self.layer_loader)
-
-        self.main_widget.show_progress(
-            f"Adding asset \"{asset_name}\" into QGIS",
-            minimum=0,
-            maximum=100,
-        )
-        self.main_widget.update_progress_bar(0)
-        log(tr("Started adding asset into QGIS"))
-
-    def add_layer(self):
-        """ Adds layer into the current QGIS project.
-            For the layer to be added successfully, the task for loading
-            layer need to exist and the corresponding layer need to be
-            available.
-        """
-        if self.layer_loader and self.layer_loader.layer:
-            layer = self.layer_loader.layer
-            QgsProject.instance().addMapLayer(layer)
-
-            message = tr("Sucessfully added asset as a map layer")
-            level = Qgis.Info
-        elif self.layer_loader and self.layer_loader.error:
-            message = self.layer_loader.error
-            level = Qgis.Critical
-        else:
-            message = tr("Problem fetching asset and loading it, into QGIS")
-            level = Qgis.Critical
-
-        self.update_inputs(True)
-        log(message)
-        self.main_widget.show_message(
-            message,
-            level=level
-        )
-
-    def layer_loader_terminated(self):
-        """ Shows message to user when layer loading task has been terminated"""
-        message = tr("QGIS background task for loading assets was terminated.")
-        self.update_inputs(True)
-        log(message)
-        self.main_widget.show_message(
-            message,
-            level=Qgis.Critical
-        )
-
-    def handle_layer_error(self, message):
-        """ Handles the error message from the layer loading task
-
-        :param message: The error message
-        :type message: str
-        """
-        self.update_inputs(True)
-        log(message)
-        self.main_widget.show_message(
-            message
-        )
 
     def add_thumbnail(self):
         """ Downloads and loads the STAC Item thumbnail"""
@@ -400,71 +246,3 @@ class ThumbnailLoader(QgsTask):
         else:
             log(tr("Couldn't load thumbnail"))
 
-
-class LayerLoader(QgsTask):
-    """ Prepares and loads items as assets inside QGIS as layers."""
-    def __init__(
-        self,
-        layer_uri,
-        layer_name,
-        layer_type
-    ):
-
-        super().__init__()
-        self.layer_uri = layer_uri
-        self.layer_name = layer_name
-        self.layer_type = layer_type
-        self.error = None
-        self.layer = None
-
-    def run(self):
-        """ Operates the main layers loading logic
-        """
-        log(
-            tr("Fetching layers in a background task.")
-        )
-        if self.layer_type is QgsMapLayer.RasterLayer:
-            self.layer = QgsRasterLayer(
-                self.layer_uri,
-                self.layer_name
-            )
-            return self.layer.isValid()
-        elif self.layer_type is QgsMapLayer.VectorLayer:
-            self.layer = QgsVectorLayer(
-                self.layer_uri,
-                self.layer_name,
-                AssetLayerType.VECTOR.value
-            )
-            return self.layer.isValid()
-        else:
-            raise NotImplementedError
-
-        return False
-
-    def finished(self, result: bool):
-        """ Calls the handler responsible for adding the
-         layer into QGIS project.
-
-        :param result: Whether the run() operation finished successfully
-        :type result: bool
-        """
-        if result and self.layer:
-            log(
-                f"Fetched layer with URI"
-                f"{self.layer_uri} "
-            )
-            # Due to the way QGIS is handling layers sharing between tasks and
-            # the main thread, sending the layer to the main thread
-            # without cloning it can lead to unpredicted crashes,
-            # hence we clone the layer before storing it, so it can
-            # be used in the main thread.
-            self.layer = self.layer.clone()
-        else:
-            self.error = tr(
-                f"Couldn't load layer "
-                f"{self.layer_uri},"
-                f"error {self.layer.dataProvider().error()}"
-            )
-            log(
-                self.error
-            )

--- a/src/qgis_stac/main.py
+++ b/src/qgis_stac/main.py
@@ -77,35 +77,50 @@ class QgisStac:
             callback,
             enabled_flag=True,
             add_to_menu=True,
+            add_to_web_menu=True,
             add_to_toolbar=True,
             status_tip=None,
             whats_this=None,
             parent=None,
     ):
         """Add a toolbar icon to the toolbar.
+
         :param icon_path: Path to the icon for this action. Can be a resource
             path (e.g. ':/plugins/foo/bar.png') or a normal file system path.
         :type icon_path: str
+
         :param text: Text that should be shown in menu items for this action.
         :type text: str
+
         :param callback: Function to be called when the action is triggered.
         :type callback: function
+
         :param enabled_flag: A flag indicating if the action should be enabled
             by default. Defaults to True.
         :type enabled_flag: bool
+
         :param add_to_menu: Flag indicating whether the action should also
             be added to the menu. Defaults to True.
         :type add_to_menu: bool
+
+        :param add_to_web_menu: Flag indicating whether the action
+            should also be added to the web menu. Defaults to True.
+        :type add_to_web_menu: bool
+
         :param add_to_toolbar: Flag indicating whether the action should also
             be added to the toolbar. Defaults to True.
         :type add_to_toolbar: bool
+
         :param status_tip: Optional text to show in a popup when mouse pointer
             hovers over the action.
         :type status_tip: str
+
         :param parent: Parent widget for the new action. Defaults None.
         :type parent: QWidget
+
         :param whats_this: Optional text to show in the status bar when the
             mouse pointer hovers over the action.
+
         :returns: The action that was created. Note that the action is also
             added to self.actions list.
         :rtype: QAction
@@ -124,6 +139,13 @@ class QgisStac:
 
         if add_to_menu:
             self.iface.addPluginToMenu(self.menu, action)
+
+        if add_to_web_menu:
+            self.iface.addPluginToWebMenu(
+                self.menu,
+                action
+            )
+
         if add_to_toolbar:
             self.toolbar.addAction(action)
 

--- a/src/qgis_stac/ui/asset_widget.ui
+++ b/src/qgis_stac/ui/asset_widget.ui
@@ -53,17 +53,17 @@
      <item row="0" column="1">
       <widget class="QPushButton" name="load_btn">
        <property name="toolTip">
-        <string>Load the asset as a layer</string>
+        <string>Load asset as a layer</string>
        </property>
        <property name="text">
-        <string>Load asset as layer</string>
+        <string>Add asset as layer</string>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
       <widget class="QPushButton" name="download_btn">
        <property name="toolTip">
-        <string>Download the asset to filesystem</string>
+        <string>Download asset to the filesystem</string>
        </property>
        <property name="text">
         <string>Download asset</string>

--- a/src/qgis_stac/ui/asset_widget.ui
+++ b/src/qgis_stac/ui/asset_widget.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AssetWidget</class>
+ <widget class="QWidget" name="AssetWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>931</width>
+    <height>45</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>222</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Asset</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="title_la">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QPushButton" name="load_btn">
+       <property name="toolTip">
+        <string>Load the asset as a layer</string>
+       </property>
+       <property name="text">
+        <string>Load asset as layer</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="download_btn">
+       <property name="toolTip">
+        <string>Download the asset to filesystem</string>
+       </property>
+       <property name="text">
+        <string>Download asset</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qgis_stac/ui/item_assets_widget.ui
+++ b/src/qgis_stac/ui/item_assets_widget.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="title">
+     <property name="styleSheet">
+      <string notr="true">font: 16pt;</string>
+     </property>
      <property name="text">
       <string/>
      </property>
@@ -32,7 +35,7 @@
         <x>0</x>
         <y>0</y>
         <width>899</width>
-        <height>255</height>
+        <height>248</height>
        </rect>
       </property>
      </widget>

--- a/src/qgis_stac/ui/item_assets_widget.ui
+++ b/src/qgis_stac/ui/item_assets_widget.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AssetsDialog</class>
+ <widget class="QWidget" name="AssetsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>919</width>
+    <height>298</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Assets</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="title">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scroll_area">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>899</width>
+        <height>255</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qgis_stac/ui/item_assets_widget.ui
+++ b/src/qgis_stac/ui/item_assets_widget.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="title">
      <property name="styleSheet">
-      <string notr="true">font: 16pt;</string>
+      <string notr="true">font: 14pt;</string>
      </property>
      <property name="text">
       <string/>
@@ -25,23 +25,47 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scroll_area">
+    <widget class="QFrame" name="frame">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
      </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>899</width>
-        <height>248</height>
-       </rect>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
       </property>
-     </widget>
+      <property name="topMargin">
+       <number>12</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QScrollArea" name="scroll_area">
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>899</width>
+           <height>238</height>
+          </rect>
+         </property>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/qgis_stac/ui/item_assets_widget.ui
+++ b/src/qgis_stac/ui/item_assets_widget.ui
@@ -26,6 +26,9 @@
    </item>
    <item>
     <widget class="QScrollArea" name="scroll_area">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
      <property name="widgetResizable">
       <bool>true</bool>
      </property>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>940</width>
-    <height>897</height>
+    <width>917</width>
+    <height>868</height>
    </rect>
   </property>
   <property name="font">
@@ -221,7 +221,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="0" column="0">
@@ -306,7 +306,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -322,7 +322,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_12">
           <item>
@@ -564,8 +564,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>898</width>
-            <height>735</height>
+            <width>875</width>
+            <height>706</height>
            </rect>
           </property>
          </widget>
@@ -660,49 +660,11 @@
          <property name="title">
           <string>Configurations</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_9">
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_6">
-              <item>
-               <widget class="QLabel" name="label_name">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Timeout</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_7">
-              <item>
-               <widget class="QSpinBox" name="spinBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
-             <widget class="QLabel" name="label_3">
+         <layout class="QGridLayout" name="gridLayout_10">
+          <item row="2" column="0">
+           <layout class="QGridLayout" name="gridLayout_11">
+            <item row="1" column="0">
+             <widget class="QLabel" name="download_folder">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -723,7 +685,48 @@
               </property>
              </widget>
             </item>
-            <item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="timeout_la">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Timeout</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="timeout_spin_box">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>9999</number>
+              </property>
+              <property name="value">
+               <number>120</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
              <widget class="QgsFileWidget" name="download_folder_btn">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -733,7 +736,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>0</width>
+                <width>100</width>
                 <height>30</height>
                </size>
               </property>
@@ -751,7 +754,14 @@
               </property>
              </widget>
             </item>
-            <item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="seconds">
+              <property name="text">
+               <string>seconds</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
              <widget class="QPushButton" name="open_folder_btn">
               <property name="minimumSize">
                <size>
@@ -773,7 +783,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_2">
+        <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -663,7 +663,7 @@
          <layout class="QGridLayout" name="gridLayout_10">
           <item row="2" column="0">
            <layout class="QGridLayout" name="gridLayout_11">
-            <item row="1" column="0">
+            <item row="0" column="0">
              <widget class="QLabel" name="download_folder">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -685,48 +685,23 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="timeout_la">
-              <property name="enabled">
-               <bool>true</bool>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="open_folder_btn">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
               </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+              <property name="toolTip">
+               <string>Click to open the download folder</string>
               </property>
               <property name="text">
-               <string>Timeout</string>
+               <string>Open</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QSpinBox" name="timeout_spin_box">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>9999</number>
-              </property>
-              <property name="value">
-               <number>120</number>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
              <widget class="QgsFileWidget" name="download_folder_btn">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -751,29 +726,6 @@
               </property>
               <property name="options">
                <set>QFileDialog::ShowDirsOnly</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QLabel" name="seconds">
-              <property name="text">
-               <string>seconds</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QPushButton" name="open_folder_btn">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Click to open the download folder</string>
-              </property>
-              <property name="text">
-               <string>Open</string>
               </property>
              </widget>
             </item>

--- a/src/qgis_stac/ui/result_item_widget.ui
+++ b/src/qgis_stac/ui/result_item_widget.ui
@@ -154,28 +154,24 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="assets_load_box">
-            <property name="toolTip">
-             <string>Add item assets as layers</string>
+           <widget class="QPushButton" name="view_assets_btn">
+            <property name="text">
+             <string>View assets</string>
             </property>
-            <item>
-             <property name="text">
-              <string>Add assets as layers</string>
-             </property>
-            </item>
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="assets_download_box">
-            <property name="toolTip">
-             <string>Download item assets</string>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
-            <item>
-             <property name="text">
-              <string>Download assets</string>
-             </property>
-            </item>
-           </widget>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </item>


### PR DESCRIPTION
Reorganized the way item assets are downloaded and loaded into QGIS.

These changes contain modification to main plugin widget to subclass a QDialog instead of QWidget so as to make it modal, blocking input from other application widgets.

Screenshot
![update_assets](https://user-images.githubusercontent.com/2663775/148061636-de63c50a-48a6-42d8-84f9-849f5cf17076.gif)
