### PR TITLE
Fix for UI lag after fetching collections

### DIFF
--- a/src/qgis_stac/conf.py
+++ b/src/qgis_stac/conf.py
@@ -702,16 +702,16 @@ class SettingsManager(QtCore.QObject):
         current_connection = self.get_current_connection()
         if filters.collections:
             self.delete_all_collections(current_connection)
-        for collection in filters.collections:
-            collection = CollectionSettings(
-                collection_id=uuid.uuid4(),
-                id=collection.id,
-                title=collection.title
-            )
-            self.save_collection(
-                current_connection,
-                collection
-            )
+            for collection in filters.collections:
+                collection = CollectionSettings(
+                    collection_id=uuid.uuid4(),
+                    id=collection.id,
+                    title=collection.title
+                )
+                self.save_collection(
+                    current_connection,
+                    collection
+                )
 
     def get_search_filters(self):
         """ Retrieve the store fitlers settings"""

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -132,6 +132,7 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         self.prepare_filter_box()
 
         # actions that trigger saving filters to the plugin settings
+
         self.start_dte.valueChanged.connect(self.save_filters)
         self.end_dte.valueChanged.connect(self.save_filters)
         self.extent_box.extentChanged.connect(self.save_filters)
@@ -187,10 +188,9 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
                 role=QtCore.Qt.UserRole)
         )
 
-        # TODO figure out why highlighting can cause text input to be slow
-        # self.highlighter = JsonHighlighter(self.filter_edit.document())
-        # self.filter_edit.cursorPositionChanged.connect(
-        #     self.highlighter.rehighlight)
+        self.highlighter = JsonHighlighter(self.filter_edit.document())
+        self.filter_edit.cursorPositionChanged.connect(
+            self.highlighter.rehighlight)
 
     def add_connection(self):
         """ Adds a new connection into the plugin, then updates
@@ -495,7 +495,7 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
             self.model.removeRows(0, self.model.rowCount())
             self.current_collections = results
             self.load_collections(results)
-            self.save_filters()
+            self.save_filters(collections=self.current_collections)
 
         elif self.search_type == ResourceType.FEATURE:
 
@@ -739,13 +739,15 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         if not result[0]:
             self.show_message(result[1], level=Qgis.Critical)
 
-    def save_filters(self):
+    def save_filters(self, collections=None):
         """ Save search filters fetched from the corresponding UI inputs """
         filter_lang = self.filter_lang_cmb.itemData(
             self.filter_lang_cmb.currentIndex()
         )
+        collections = collections if isinstance(collections, list) else None
+
         filters = SearchFilters(
-            collections=self.current_collections,
+            collections=collections,
             start_date=(
                 self.start_dte.dateTime()
                 if not self.start_dte.dateTime().isNull() else None


### PR DESCRIPTION
After the get collections activity finishes a UI lag appears on the plugin search tab input widgets, this was because of the 
save filter operation that was saving the collections into the plugin settings each time any on the inputs widget were altered.

This PR updates the collections save function to only operate once the collections have been fetched.

Old behaviour
![ui_lag](https://user-images.githubusercontent.com/2663775/150117507-dfd94919-fee2-4270-b8cd-2a7472355c66.gif)

New behaviour
![no_ui_lag](https://user-images.githubusercontent.com/2663775/150118049-76a1e444-a4db-4f63-b1cd-e808defe8729.gif)

