### PR TITLE
Change collections list to display collection ID in brackets if no title

### DIFF
--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -692,7 +692,7 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         )
 
         for result in collections:
-            title = result.title if result.title else tr("No Title")
+            title = result.title if result.title else tr("No Title") + f" ({result.id})"
             item = QtGui.QStandardItem(title)
             item.setData(result.id, 1)
             self.model.appendRow(item)


### PR DESCRIPTION
I have been testing this plugin and connecting to a STAC server where the collections haven't been given titles. Currently each of these collections displays in the collections list as `No Title`. This PR updates this so that any collections without a title are displayed as `No Title (collection_id)` - for example `No Title (test-collection)`, so that they can be distinguished.