### PR TITLE
Change in tests mock app server

### DIFF
--- a/test/mock/mock_http_server.py
+++ b/test/mock/mock_http_server.py
@@ -1,6 +1,8 @@
 import os
 import requests
 
+import multiprocessing
+
 from flask import jsonify, request
 from threading import Thread
 

--- a/test/test_stac_api_client.py
+++ b/test/test_stac_api_client.py
@@ -4,6 +4,8 @@
 """
 import unittest
 
+from multiprocessing import Process
+
 from mock.mock_http_server import MockSTACApiServer
 from qgis.PyQt.QtTest import QSignalSpy
 
@@ -14,9 +16,13 @@ from qgis_stac.api.models import ItemSearch
 class STACApiClientTest(unittest.TestCase):
 
     def setUp(self):
-        self.server = MockSTACApiServer()
+
+        app_server = MockSTACApiServer()
+
+        self.server = Process(target=app_server.run)
         self.server.start()
-        self.api_client = Client(self.server.url)
+
+        self.api_client = Client(app_server.url)
         self.response = None
 
     def test_resources_fetch(self):
@@ -77,7 +83,8 @@ class STACApiClientTest(unittest.TestCase):
         self.response = response_args
 
     def tearDown(self):
-        self.server.shutdown_server()
+        self.server.terminate()
+        self.server.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updates the logic in shutting down the mock server for testing, the past approach was causing the CI to hold when running the tests on environments that contains latest `Wezkzeug` package.

Now using `Process` class to handle server start and termination as the `werkzeug.server.shutdown` is deprecated in Werkzeug 2.0. see https://github.com/pallets/werkzeug/issues/1752 and https://werkzeug.palletsprojects.com/en/2.1.x/serving/#shutting-down-the-server