### PR TITLE
Thumbnail update

### DIFF
--- a/src/qgis_stac/definitions/constants.py
+++ b/src/qgis_stac/definitions/constants.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+    Plugin constants
+"""
+
+THUMBNAIL_HEIGHT_PARAM = 'height'
+THUMBNAIL_WIDTH_PARAM = 'width'
+
+THUMBNAIL_HEIGHT = 200
+THUMBNAIL_WIDTH = 200

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -87,10 +87,17 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         self.created_date.setText(
             datetime_str
         )
+        thumbnail_url = None
+        overview_url = None
 
         for asset in self.item.assets:
             if AssetRoles.THUMBNAIL.value in asset.roles:
-                self.thumbnail_url = asset.href
+                thumbnail_url = asset.href
+
+            elif AssetRoles.OVERVIEW.value in asset.roles:
+                overview_url = asset.href
+
+        self.thumbnail_url = thumbnail_url if thumbnail_url else overview_url
 
         self.view_assets_btn.setEnabled(self.item.assets is not None)
         self.view_assets_btn.clicked.connect(self.open_assets_dialog)


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/125

Use overview asset as a thumbnail if an item doesn't have a thumbnail asset, and when fetching the overview append height and width url params to get a thumbnail like size.