### PR TITLE
Show selected collections

### DIFF
--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -113,6 +113,8 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         self.proxy_model.setSortCaseSensitivity(QtCore.Qt.CaseInsensitive)
 
         self.collections_tree.setModel(self.proxy_model)
+        self.collections_tree.selectionModel().selectionChanged.connect(self.display_selected_collection)
+        self.selected_collections_la.hide()
 
         self.filter_text.textChanged.connect(self.filter_changed)
 
@@ -479,6 +481,16 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         self.extent_box.setMapCanvas(map_canvas)
         self.extent_box.setChecked(False)
 
+    def display_selected_collection(self):
+        self.selected_collections_la.show()
+        collections = self.get_selected_collections(title=True)
+
+        self.selected_collections_la.setText(
+            tr("Selected collections: <b>{}</b>").format(
+                ', '.join(collections)
+            )
+        )
+
     def display_results(self, results, pagination):
         """ Shows the found results into their respective view. Emits
         the search end signal after completing loading up the results
@@ -664,18 +676,22 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
 
         self.populate_results(sorted_data)
 
-    def get_selected_collections(self):
-        """ Gets the currently selected collections ids from the collection
+    def get_selected_collections(self, title=False):
+        """ Gets the currently selected collections from the collection
         view.
 
-        :returns: Collection ids
+        :param title: Whether to return collection titles or ids
+        :type title: bool
+
+        :returns: Collection
         :rtype: list
         """
+        data_index = 0 if title else 1
         indexes = self.collections_tree.selectionModel().selectedIndexes()
         collections_ids = []
 
         for index in indexes:
-            collections_ids.append(index.data(1))
+            collections_ids.append(index.data(data_index))
 
         return collections_ids
 

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -113,7 +113,9 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         self.proxy_model.setSortCaseSensitivity(QtCore.Qt.CaseInsensitive)
 
         self.collections_tree.setModel(self.proxy_model)
-        self.collections_tree.selectionModel().selectionChanged.connect(self.display_selected_collection)
+        self.collections_tree.selectionModel().selectionChanged.connect(
+            self.display_selected_collection
+        )
         self.selected_collections_la.hide()
 
         self.filter_text.textChanged.connect(self.filter_changed)
@@ -482,6 +484,9 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         self.extent_box.setChecked(False)
 
     def display_selected_collection(self):
+        """ Shows the current selected collections in the
+        targeted label
+        """
         self.selected_collections_la.show()
         collections = self.get_selected_collections(title=True)
 

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -151,6 +151,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QLabel" name="selected_collections_la">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
              <widget class="QTreeView" name="collections_tree">


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/131

Adds a label that will be used to display current selected collections from the collection list.

screenshot showing how the selected collections will be displayed
![shown_selected_collections](https://user-images.githubusercontent.com/2663775/164432302-09dfce4b-2f86-40bb-a3b9-92f43a7a072c.gif)

