### PR TITLE
Support CQL2 JSON

### DIFF
--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -270,8 +270,10 @@ class ItemSearch:
 
         text = json.loads(self.filter_text) if self.filter_text else None
 
+        filter_lang = self.filter_lang.value.lower() if self.filter_lang else None
+
         filter_text = text \
-            if self.filter_lang == FilterLang.CQL_JSON else None
+            if self.filter_lang in [FilterLang.CQL_JSON, FilterLang.CQL2_JSON] else None
         query_text = text \
             if self.filter_lang == FilterLang.STAC_QUERY else None
 
@@ -281,6 +283,7 @@ class ItemSearch:
             "limit": self.page_size,
             "bbox": bbox,
             "datetime": datetime_str,
+            "filter_lang": filter_lang,
             "filter": filter_text,
             "query": query_text,
         }

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -270,12 +270,22 @@ class ItemSearch:
 
         text = json.loads(self.filter_text) if self.filter_text else None
 
-        filter_lang = self.filter_lang.value.lower() if self.filter_lang else None
+        filter_lang_values = {
+            FilterLang.CQL_JSON: 'cql-json',
+            FilterLang.CQL2_JSON: 'cql2-json',
+            FilterLang.CQL_TEXT: 'cql-text'
+        }
+
+        filter_lang_text = filter_lang_values[self.filter_lang] \
+            if self.filter_lang else None
 
         filter_text = text \
             if self.filter_lang in [FilterLang.CQL_JSON, FilterLang.CQL2_JSON] else None
         query_text = text \
             if self.filter_lang == FilterLang.STAC_QUERY else None
+
+        from ..utils import log
+        log(f"Filter lang is {self.filter_lang}, filter lang text {filter_lang_text}")
 
         parameters = {
             "ids": self.ids,
@@ -283,7 +293,7 @@ class ItemSearch:
             "limit": self.page_size,
             "bbox": bbox,
             "datetime": datetime_str,
-            "filter_lang": filter_lang,
+            "filter_lang": filter_lang_text,
             "filter": filter_text,
             "query": query_text,
         }

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -180,6 +180,7 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
 
         labels = {
             FilterLang.CQL_JSON: tr("CQL_JSON"),
+            FilterLang.CQL2_JSON: tr("CQL2_JSON"),
             FilterLang.STAC_QUERY: tr("STAC_QUERY"),
         }
         for lang_type, item_text in labels.items():


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/128

Updated the filter languages that can be used in the plugin, now the plugin supports CQL2 JSON usage.

Screenshot of the plugin search using CQL2 JSON language
![cql2_inaction](https://user-images.githubusercontent.com/2663775/164475189-1b5a6f78-6584-4f59-81b5-a00591220b8f.gif)

