### PR TITLE
Implement dialog for showing STAC collection details

### DIFF
--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -140,12 +140,14 @@ class ResourceAsset:
     roles: typing.List[str]
 
 
+@dataclasses.dataclass
 class ResourceExtent:
     """The STAC API extent"""
     spatial: SpatialExtent
     temporal: TemporalExtent
 
 
+@dataclasses.dataclass
 class ResourceLink:
     """The STAC API link resource"""
     href: str
@@ -178,8 +180,8 @@ class ResourceProvider:
     """
     name: str
     description: str
-    roles: str
-    urls: [str]
+    roles: [str]
+    url: str
 
 
 # TODO Update the geometry coordinates type to include
@@ -206,7 +208,7 @@ class Catalog:
 @dataclasses.dataclass
 class Collection:
     """ Represents the STAC API Collection"""
-    id: int = None
+    id: str = None
     uuid: UUID = None
     title: str = None
     description: str = None

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -143,7 +143,7 @@ class ContentFetcherTask(QgsTask):
                 providers.append(resource_provider)
             links = []
             for link in collection.links:
-                link_dict = link.__dict__
+                link_dict = vars(link)
                 link_type = link_dict.get('type') \
                     if 'type' in link_dict.keys() \
                     else link_dict.get('media_type')
@@ -154,11 +154,11 @@ class ContentFetcherTask(QgsTask):
                     type=link_type
                 )
                 links.append(resource_link)
-            spatial = collection.extent.spatial.__dict__
+            spatial = vars(collection.extent.spatial)
             bbox = spatial.get('bbox') \
                 if 'bbox' in spatial.keys() else spatial.get('bboxes')
 
-            temporal = collection.extent.temporal.__dict__
+            temporal = vars(collection.extent.temporal)
             interval = temporal.get('interval') \
                 if 'bbox' in spatial.keys() else spatial.get('intervals')
             spatial_extent = SpatialExtent(
@@ -173,14 +173,24 @@ class ContentFetcherTask(QgsTask):
                 temporal=temporal_extent
             )
 
+            # Avoid Attribute error and assign None to properties that are not available
+            collection_dict = vars(collection)
+            id = collection_dict.get('id', None)
+            title = collection_dict.get('title', None)
+            description = collection_dict.get('description', None)
+            keywords = collection_dict.get('keywords', None)
+            license = collection_dict.get('license', None)
+            stac_version = collection_dict.get('stac_version', None)
+            summaries = collection_dict.get('summaries', None)
+
             collection_result = Collection(
-                id=collection.id,
-                title=collection.title,
-                description=collection.description,
-                keywords=collection.keywords,
-                license=collection.license,
-                stac_version=None,
-                summaries=collection.summaries,
+                id=id,
+                title=title,
+                description=description,
+                keywords=keywords,
+                license=license,
+                stac_version=stac_version,
+                summaries=summaries,
                 links=links,
                 extent=extent,
             )

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -145,7 +145,8 @@ class ContentFetcherTask(QgsTask):
             for link in collection.links:
                 link_dict = link.__dict__
                 link_type = link_dict.get('type') \
-                    if 'type' in link_dict.keys() else link_dict.get('media_type')
+                    if 'type' in link_dict.keys() \
+                    else link_dict.get('media_type')
                 resource_link = ResourceLink(
                     href=link.href,
                     rel=link.rel,

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -17,9 +17,13 @@ from .models import (
     Item,
     ItemSearch,
     ResourceAsset,
+    ResourceExtent,
+    ResourceLink,
     ResourcePagination,
     ResourceProperties,
     ResourceType,
+    SpatialExtent,
+    TemporalExtent
 )
 
 from ..lib import planetary_computer as pc
@@ -127,9 +131,37 @@ class ContentFetcherTask(QgsTask):
         """
         collections = []
         for collection in collections_response:
+            links = []
+            for link in collection.links:
+                resource_link = ResourceLink(
+                    href=link.href,
+                    rel=link.rel,
+                    title=link.title,
+                    type=link.type
+                )
+                links.append(resource_link)
+            spatial_extent = SpatialExtent(
+                bbox=collection.bbox
+            )
+            temporal_extent = TemporalExtent(
+                interval=collection.interval
+            )
+
+            extent = ResourceExtent(
+                spatial=spatial_extent,
+                temporal=temporal_extent
+            )
+
             collection_result = Collection(
                 id=collection.id,
-                title=collection.title
+                title=collection.title,
+                description=collection.description,
+                keywords=collection.keywords,
+                license=collection.license,
+                stac_version=collection.stac_version,
+                summaries=collection.summaries,
+                links=links,
+                extent=extent,
             )
             collections.append(collection_result)
         return collections

--- a/src/qgis_stac/conf.py
+++ b/src/qgis_stac/conf.py
@@ -596,8 +596,16 @@ class SettingsManager(QtCore.QObject):
         self.save_collection_extent(collection_settings.extent, settings_key)
         self.save_collection_providers(collection_settings.providers, settings_key)
 
-
     def save_collection_links(self, links, key):
+        """ Saves the collection links into plugin settings
+        using the provided settings group key.
+
+        :param links: List of collection links
+        :type links: []
+
+        :param key: QgsSettings group key.
+        :type key: str
+        """
         for link in links or []:
             link_uuid = uuid.uuid4()
             settings_key = f"{key}/links/{link_uuid}"
@@ -608,6 +616,15 @@ class SettingsManager(QtCore.QObject):
                 settings.setValue("type", link.type)
 
     def save_collection_providers(self, providers, key):
+        """ Saves the collection provider into plugin settings
+        using the provided settings group key.
+
+        :param links: List of collection providers
+        :type links: []
+
+        :param key: QgsSettings group key.
+        :type key: str
+        """
         for provider in providers or []:
             provider_uuid = uuid.uuid4()
             settings_key = f"{key}/links/{provider_uuid}"
@@ -617,8 +634,16 @@ class SettingsManager(QtCore.QObject):
                 settings.setValue("role", provider.role)
                 settings.setValue("url", provider.url)
 
-
     def save_collection_extent(self, extent, key):
+        """ Saves the collection extent into plugin settings
+        using the provided settings group key.
+
+        :param links: Collection extent
+        :type links: models.Extent
+
+        :param key: QgsSettings group key.
+        :type key: str
+        """
         interval = extent.temporal.interval
         spatial_extent = extent.spatial.bbox
 
@@ -629,7 +654,6 @@ class SettingsManager(QtCore.QObject):
         temporal_key = f"{key}/extent/temporal/"
         with qgis_settings(temporal_key) as settings:
             settings.setValue("interval", interval)
-
 
     def get_collection(self, identifier, connection):
         """ Retrieves the collection with the identifier

--- a/src/qgis_stac/gui/collection_dialog.py
+++ b/src/qgis_stac/gui/collection_dialog.py
@@ -2,6 +2,8 @@ import os
 
 from qgis.PyQt import QtCore, QtGui, QtWidgets
 
+from qgis.core import QgsCoordinateReferenceSystem, QgsRectangle
+
 
 from qgis.PyQt.uic import loadUiType
 
@@ -27,8 +29,64 @@ class CollectionDialog(QtWidgets.QDialog, DialogUi):
         self.collection = collection
 
         if self.collection:
-            self.name.setText(self.collection.id)
-            self.title.setText(self.collection.title)
-            self.keywords.setText(self.collection.keywords)
-            self.description.setText(self.collection.description)
-            self.licence.setText(self.collection.license)
+            self.id_le.setText(self.collection.id)
+            self.title_le.setText(self.collection.title)
+            if self.collection.keywords:
+                self.populate_keywords(collection.keywords)
+            self.description_le.setText(self.collection.description)
+
+            if self.collection.license:
+                self.license_le.setText(self.collection.license)
+
+            if self.collection.extent:
+                self.set_extent(collection.extent)
+
+    def populate_keywords(self, keywords):
+        self.keywords_table.setRowCount(0)
+        for keyword in keywords:
+            self.keywords_table.insertRow(self.keywords_table.rowCount())
+            row = self.keywords_table.rowCount() - 1
+            item = QtWidgets.QTableWidgetItem(keyword)
+            self.keywords_table.setItem(row, 0, item)
+
+    def set_extent(self, extent):
+        spatial_extent = extent.spatial
+        if spatial_extent:
+            self.spatialExtentSelector.setOutputCrs(
+                QgsCoordinateReferenceSystem("EPSG:4326")
+            )
+            original_extent = QgsRectangle()
+            self.spatialExtentSelector.setOriginalExtent(
+                original_extent,
+                QgsCoordinateReferenceSystem("EPSG:4326")
+            )
+            self.spatialExtentSelector.setOutputExtentFromOriginal()
+
+        temporal_extents = extent.temporal
+        if temporal_extents:
+            pass
+        else:
+            self.from_date.clear()
+            self.to_date.clear()
+
+    def set_links(self, links):
+
+        self.links_table.setRowCount(0)
+        for link in links:
+            self.links_table.insertRow(self.links_table.rowCount())
+            row = self.links_table.rowCount() - 1
+            self.links_table.setItem(row, 0,  QtWidgets.QTableWidgetItem(link.href))
+            self.links_table.setItem(row, 1, QtWidgets.QTableWidgetItem(link.rel))
+            self.links_table.item(row, 2, QtWidgets.QTableWidgetItem(link.type))
+            self.links_table.item(row, 3, QtWidgets.QTableWidgetItem(link.title))
+
+    def set_providers(self, providers):
+
+        self.providers_table.setRowCount(0)
+        for provider in providers:
+            self.providers_table.insertRow(self.providers_table.rowCount())
+            row = self.providers_table.rowCount() - 1
+            self.providers_table.item(row, 0, QtWidgets.QTableWidgetItem(provider.name))
+            self.providers_table.item(row, 1, QtWidgets.QTableWidgetItem(provider.description))
+            self.providers_table.item(row, 2, QtWidgets.QTableWidgetItem(provider.roles))
+            self.providers_table.item(row, 3, QtWidgets.QTableWidgetItem(provider.url))

--- a/src/qgis_stac/gui/collection_dialog.py
+++ b/src/qgis_stac/gui/collection_dialog.py
@@ -27,4 +27,8 @@ class CollectionDialog(QtWidgets.QDialog, DialogUi):
         self.collection = collection
 
         if self.collection:
+            self.name.setText(self.collection.id)
             self.title.setText(self.collection.title)
+            self.keywords.setText(self.collection.keywords)
+            self.description.setText(self.collection.description)
+            self.licence.setText(self.collection.license)

--- a/src/qgis_stac/gui/collection_dialog.py
+++ b/src/qgis_stac/gui/collection_dialog.py
@@ -1,0 +1,30 @@
+import os
+
+from qgis.PyQt import QtCore, QtGui, QtWidgets
+
+
+from qgis.PyQt.uic import loadUiType
+
+DialogUi, _ = loadUiType(
+    os.path.join(os.path.dirname(__file__), "../ui/collection_dialog.ui")
+)
+
+
+class CollectionDialog(QtWidgets.QDialog, DialogUi):
+    """ Dialog for displaying STAC catalog collections details"""
+
+    def __init__(
+            self,
+            collection=None
+    ):
+        """ Constructor
+
+        :param collection: Collection instance
+        :type collection: models.Collection
+        """
+        super().__init__()
+        self.setupUi(self)
+        self.collection = collection
+
+        if self.collection:
+            self.title.setText(self.collection.title)

--- a/src/qgis_stac/gui/collection_dialog.py
+++ b/src/qgis_stac/gui/collection_dialog.py
@@ -15,7 +15,7 @@ DialogUi, _ = loadUiType(
 
 
 class CollectionDialog(QtWidgets.QDialog, DialogUi):
-    """ Dialog for displaying STAC catalog collections details"""
+    """ Dialog for displaying STAC catalog collection details"""
 
     def __init__(
             self,
@@ -44,6 +44,11 @@ class CollectionDialog(QtWidgets.QDialog, DialogUi):
                 self.set_extent(collection.extent)
 
     def populate_keywords(self, keywords):
+        """ Populates the keywords list in the keyword tab
+
+        :param keywords: List of collection keywords
+        :type keywords:  []
+        """
         self.keywords_table.setRowCount(0)
         for keyword in keywords:
             self.keywords_table.insertRow(self.keywords_table.rowCount())
@@ -52,6 +57,11 @@ class CollectionDialog(QtWidgets.QDialog, DialogUi):
             self.keywords_table.setItem(row, 0, item)
 
     def set_extent(self, extent):
+        """ Sets the collection spatial and temporal extents
+
+        :param extent: Instance that contain spatial and temporal extents
+        :type extent: models.Extent
+        """
         spatial_extent = extent.spatial
         if spatial_extent:
             self.spatialExtentSelector.setOutputCrs(
@@ -82,7 +92,11 @@ class CollectionDialog(QtWidgets.QDialog, DialogUi):
             self.to_date.clear()
 
     def set_links(self, links):
+        """ Populates the links list in the link tab
 
+        :param links: List of collection links
+        :type links:  []
+        """
         self.links_table.setRowCount(0)
         for link in links:
             self.links_table.insertRow(self.links_table.rowCount())
@@ -93,7 +107,11 @@ class CollectionDialog(QtWidgets.QDialog, DialogUi):
             self.links_table.item(row, 3, QtWidgets.QTableWidgetItem(link.title))
 
     def set_providers(self, providers):
+        """ Populates the providers list in the providers tab
 
+        :param providers: List of collection providers
+        :type providers:  []
+        """
         self.providers_table.setRowCount(0)
         for provider in providers:
             self.providers_table.insertRow(self.providers_table.rowCount())

--- a/src/qgis_stac/gui/collection_dialog.py
+++ b/src/qgis_stac/gui/collection_dialog.py
@@ -4,6 +4,8 @@ from qgis.PyQt import QtCore, QtGui, QtWidgets
 
 from qgis.core import QgsCoordinateReferenceSystem, QgsRectangle
 
+from qgis.utils import iface
+
 
 from qgis.PyQt.uic import loadUiType
 
@@ -55,7 +57,17 @@ class CollectionDialog(QtWidgets.QDialog, DialogUi):
             self.spatialExtentSelector.setOutputCrs(
                 QgsCoordinateReferenceSystem("EPSG:4326")
             )
-            original_extent = QgsRectangle()
+
+            bbox = spatial_extent.bbox[0] \
+                if spatial_extent.bbox and isinstance(spatial_extent.bbox, list) \
+                else None
+
+            original_extent = QgsRectangle(
+                bbox[0],
+                bbox[1],
+                bbox[2],
+                bbox[3]
+            ) if bbox and isinstance(bbox, list) else QgsRectangle()
             self.spatialExtentSelector.setOriginalExtent(
                 original_extent,
                 QgsCoordinateReferenceSystem("EPSG:4326")

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -507,8 +507,7 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         )
 
     def collections_tree_double_clicked(self, index):
-        item = self.proxy_model.index(0, 0, index)
-        collection = item.data(1)
+        collection = self.collections_tree.model().data(index, 1)
         collection_dialog = CollectionDialog(collection)
         collection_dialog.exec_()
 

--- a/src/qgis_stac/ui/collection_dialog.ui
+++ b/src/qgis_stac/ui/collection_dialog.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NewConnectionDialog</class>
+ <widget class="QDialog" name="NewConnectionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>856</width>
+    <height>697</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Collection Information</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QGroupBox" name="collection_box">
+     <property name="title">
+      <string>Collection Information</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_name">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="title">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QLabel" name="keywords">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Keywords</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="collection_name">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="label_url">
+        <property name="text">
+         <string>Title</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Spatial extent</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Temporal extent</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QLabel" name="spatial_extent">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QLabel" name="tempora_extent">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="collections_group">
+     <property name="title">
+      <string>Links</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_10"/>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qgis_stac/ui/collection_dialog.ui
+++ b/src/qgis_stac/ui/collection_dialog.ui
@@ -27,7 +27,7 @@
      </property>
      <widget class="QWidget" name="tabIdentificationDialog">
       <attribute name="title">
-       <string>Basic</string>
+       <string>Identification</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
@@ -184,6 +184,9 @@
           <property name="text">
            <string>Keywords</string>
           </property>
+          <property name="toolTip">
+           <string>List of keywords describing the Collection</string>
+          </property>
          </column>
         </widget>
        </item>
@@ -310,7 +313,15 @@
          </attribute>
          <column>
           <property name="text">
-           <string>href</string>
+           <string>Title</string>
+          </property>
+          <property name="toolTip">
+           <string>A readable title to be used in rendered displays of the link.</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Href</string>
           </property>
           <property name="toolTip">
            <string>Type of address, e.g 'postal'</string>
@@ -318,26 +329,18 @@
          </column>
          <column>
           <property name="text">
-           <string>rel</string>
+           <string>Type</string>
           </property>
           <property name="toolTip">
-           <string>Free-form physical address component</string>
+           <string>Media type supplied by the link.</string>
           </property>
          </column>
          <column>
           <property name="text">
-           <string>type</string>
+           <string>Rel</string>
           </property>
           <property name="toolTip">
-           <string>Postal (or ZIP) code</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>title</string>
-          </property>
-          <property name="toolTip">
-           <string>City or locality name</string>
+           <string>he actual link in the format of an URL</string>
           </property>
          </column>
         </widget>
@@ -384,7 +387,7 @@
            <string>Name</string>
           </property>
           <property name="toolTip">
-           <string>Type of address, e.g 'postal'</string>
+           <string>The name of the organization or the individual.</string>
           </property>
          </column>
          <column>
@@ -392,7 +395,7 @@
            <string>Description</string>
           </property>
           <property name="toolTip">
-           <string>Free-form physical address component</string>
+           <string>Multi-line description to add further provider information.</string>
           </property>
          </column>
          <column>
@@ -400,7 +403,7 @@
            <string>Roles</string>
           </property>
           <property name="toolTip">
-           <string>Postal (or ZIP) code</string>
+           <string comment="Roles of the provider. Any of licensor, producer, processor or host.">Postal (or ZIP) code</string>
           </property>
          </column>
          <column>
@@ -408,7 +411,7 @@
            <string>URL</string>
           </property>
           <property name="toolTip">
-           <string>City or locality name</string>
+           <string extracomment="Homepage on which the provider describes the dataset and publishes contact information.">City or locality name</string>
           </property>
          </column>
         </widget>
@@ -438,5 +441,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <resources/>
  <connections/>
 </ui>

--- a/src/qgis_stac/ui/collection_dialog.ui
+++ b/src/qgis_stac/ui/collection_dialog.ui
@@ -114,7 +114,15 @@
      <property name="collapsed">
       <bool>false</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_10"/>
+     <layout class="QVBoxLayout" name="verticalLayout_10">
+      <item>
+       <widget class="QLabel" name="links">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/qgis_stac/ui/collection_dialog.ui
+++ b/src/qgis_stac/ui/collection_dialog.ui
@@ -6,123 +6,415 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>856</width>
-    <height>697</height>
+    <width>657</width>
+    <height>490</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Collection Information</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QGroupBox" name="collection_box">
-     <property name="title">
-      <string>Collection Information</string>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="enabled">
+      <bool>true</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
-       <widget class="QLabel" name="label_name">
-        <property name="text">
-         <string>Name</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="title">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QLabel" name="keywords">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="2">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Keywords</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="collection_name">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="label_url">
-        <property name="text">
-         <string>Title</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Spatial extent</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Temporal extent</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QLabel" name="spatial_extent">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QLabel" name="tempora_extent">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QgsCollapsibleGroupBox" name="collections_group">
-     <property name="title">
-      <string>Links</string>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
      </property>
-     <property name="collapsed">
-      <bool>false</bool>
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_10">
-      <item>
-       <widget class="QLabel" name="links">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <widget class="QWidget" name="tabIdentificationDialog">
+      <attribute name="title">
+       <string>Basic</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="4" column="1">
+          <widget class="QTextEdit" name="description_le">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Detailed multi-line description to fully explain the collection.</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="toolTip">
+            <string>Detailed multi-line description to fully explain the collection.</string>
+           </property>
+           <property name="text">
+            <string>Description</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="toolTip">
+            <string>Identifier for the collection that is unique across the provider.</string>
+           </property>
+           <property name="text">
+            <string>Id</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="toolTip">
+            <string>A short descriptive one-line title for the collection.</string>
+           </property>
+           <property name="text">
+            <string>Title</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_11">
+           <property name="toolTip">
+            <string>The STAC version the collection implements.</string>
+           </property>
+           <property name="text">
+            <string>STAC version</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="title_le">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>A short descriptive one-line title for the collection.</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="id_le">
+           <property name="toolTip">
+            <string>Identifier for the collection that is unique across the provider.</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="stac_version_le">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>The STAC version the collection implements.</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="license_la">
+           <property name="text">
+            <string>License</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLineEdit" name="license_le">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabKeywordsDialog">
+      <attribute name="title">
+       <string>Keywords</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>List of keywords describing the collection.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTableWidget" name="keywords_table">
+         <property name="toolTip">
+          <string>A set of descriptive keywords associated with the resource for a specified concept.</string>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Keywords</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabExtentDialog">
+      <attribute name="title">
+       <string>Extent</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_9">
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Collections spatial and  temporal extent</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsExtentGroupBox" name="spatialExtentSelector">
+         <property name="title">
+          <string>Spatial extent</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+         <property name="title">
+          <string>Temporal extent</string>
+         </property>
+         <property name="collapsed">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_15">
+            <item>
+             <widget class="QLabel" name="label_33">
+              <property name="text">
+               <string>From</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsDateTimeEdit" name="from_date"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_16">
+            <item>
+             <widget class="QLabel" name="label_34">
+              <property name="text">
+               <string>To</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsDateTimeEdit" name="to_date"/>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_35">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabLinksDialog">
+      <attribute name="title">
+       <string>Links</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QLabel" name="mLabelLinks">
+         <property name="toolTip">
+          <string>a list of online resources associated with the resource.</string>
+         </property>
+         <property name="text">
+          <string notr="true">List of available links in the collection.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTableWidget" name="links_table">
+         <property name="toolTip">
+          <string>A list of references to other documents.</string>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="showGrid">
+          <bool>true</bool>
+         </property>
+         <property name="gridStyle">
+          <enum>Qt::SolidLine</enum>
+         </property>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>href</string>
+          </property>
+          <property name="toolTip">
+           <string>Type of address, e.g 'postal'</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>rel</string>
+          </property>
+          <property name="toolTip">
+           <string>Free-form physical address component</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>type</string>
+          </property>
+          <property name="toolTip">
+           <string>Postal (or ZIP) code</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>title</string>
+          </property>
+          <property name="toolTip">
+           <string>City or locality name</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Providers</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>List of organizations that captures or processes the content of the collection.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTableWidget" name="providers_table">
+         <property name="toolTip">
+          <string>A list of providers, which may include all organizations capturing or processing the data or the hosting provider.</string>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="showGrid">
+          <bool>true</bool>
+         </property>
+         <property name="gridStyle">
+          <enum>Qt::SolidLine</enum>
+         </property>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Name</string>
+          </property>
+          <property name="toolTip">
+           <string>Type of address, e.g 'postal'</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Description</string>
+          </property>
+          <property name="toolTip">
+           <string>Free-form physical address component</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Roles</string>
+          </property>
+          <property name="toolTip">
+           <string>Postal (or ZIP) code</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>URL</string>
+          </property>
+          <property name="toolTip">
+           <string>City or locality name</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
@@ -134,7 +426,17 @@
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QgsCollapsibleGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
- <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/126

Created a new dialog for showing STAC collection information. Currently the all the catalog collections informations are stored in the plugin when fetching the catalog collections. This dialog will be used to show user the fetched collection details.

Double cliking a collection item in the collections list will open Collection dialog for the clicked collection.

When fetching the collection we now store extra collection properties including collection extent, links, providers, description, license, keywords and STAC version.

If the catalog collections spatial extent doesn't have `bbox` property as required in (https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#spatial-extent-object) we fallback to use `bboxes`, same when getting the collection temporal extent (see https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#temporal-extent-object) using `intervals` for `interval` and `media_type` for `type` in fetching collections links type (https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#link-object).

The look of the collection dialog
![collection_dialog](https://user-images.githubusercontent.com/2663775/167086998-0729f4ee-db84-4290-bf5b-78ff145ef644.gif)

