### PR TITLE
Fix file download

### DIFF
--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -63,7 +63,6 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
         self.load_btn.clicked.connect(load_asset)
         self.download_btn.clicked.connect(download_asset)
 
-
         if self.asset.type not in layer_types:
             self.load_btn.setToolTip(
                 tr("Asset contains a {} media type which"

--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -63,6 +63,7 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
         self.load_btn.clicked.connect(load_asset)
         self.download_btn.clicked.connect(download_asset)
 
+
         if self.asset.type not in layer_types:
             self.load_btn.setToolTip(
                 tr("Asset contains a {} media type which"

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -8,6 +8,8 @@ import os
 from pathlib import Path
 from osgeo import ogr
 
+from functools import partial
+
 from qgis import processing
 
 from qgis.PyQt import QtCore, QtGui, QtWidgets
@@ -169,6 +171,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         self.download_result["file"] = output
 
         params = {'URL': url, 'OUTPUT': output}
+
         try:
             self.main_widget.show_message(
                 tr("Download for file {} to {} has started."
@@ -217,7 +220,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             )
 
     def clean_filename(self, filename):
-        """ Create a safe filename by removing operating system
+        """ Creates a safe filename by removing operating system
         invalid filename characters.
 
         :param filename: File name

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -167,10 +167,9 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         output = os.path.join(
             item_folder, title
         ) if item_folder else QgsProcessing.TEMPORARY_OUTPUT
+        params = {'URL': url, 'OUTPUT': output}
 
         self.download_result["file"] = output
-
-        params = {'URL': url, 'OUTPUT': output}
 
         try:
             self.main_widget.show_message(
@@ -248,6 +247,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             AssetLayerType.COG.value,
             AssetLayerType.GEOTIFF.value,
             AssetLayerType.NETCDF.value,
+            AssetLayerType.X_NETCDF.value
         ])
         vector_types = ','.join([
             AssetLayerType.GEOJSON.value,

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -739,8 +739,12 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
                     level=Qgis.Critical
                 )
         else:
+            settings_manager.set_value(
+                Settings.DOWNLOAD_FOLDER,
+                folder
+            )
             self.show_message(
-                tr('Download folder has not been set'),
+                tr('Download folder has been removed'),
                 level=Qgis.Warning
             )
 

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -744,7 +744,10 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
                 folder
             )
             self.show_message(
-                tr('Download folder has been removed'),
+                tr(
+                    'Download folder has not been set, '
+                   'a system temporary folder will be used'
+                   ),
                 level=Qgis.Warning
             )
 


### PR DESCRIPTION
These changes contain fix for issues when downloading item assets that have filenames with invalid characters, updates that enables progress bar to show progress value when downloading  the item assets and when the download folder is not set the plugin will use a system temporary folder as a download destination( see https://api.qgis.org/api/classQgsProcessing.html#a62584b5ed1558ebdf04a95d6f4a9d403)

Screenshot showing how download progress will be shown
![download_progress](https://user-images.githubusercontent.com/2663775/167425718-58c391e8-1470-4c93-a1b5-38d1c7eeceb0.gif)

