### PR TITLE
Load downloaded asset into QGIS

### DIFF
--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -48,6 +48,7 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
         layer_types = [
             AssetLayerType.COG.value,
             AssetLayerType.GEOTIFF.value,
+            AssetLayerType.NETCDF.value,
         ]
 
         self.title_la.setText(self.asset.title)
@@ -57,7 +58,8 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
         )
         download_asset = partial(
             self.asset_dialog.download_asset,
-            self.asset
+            self.asset,
+            True
         )
         self.load_btn.setEnabled(self.asset.type in layer_types)
         self.load_btn.clicked.connect(load_asset)

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -128,7 +128,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         self.parent.update_inputs(enabled)
 
     def download_asset(self, asset, load_asset=False):
-        """ Downloads asset into directory defined in the plugin settings.
+        """ Downloads the passed asset into directory defined in the plugin settings.
 
         :param asset: Item asset
         :type asset: models.ResourceAsset
@@ -199,12 +199,13 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             )
             feedback.progressChanged.connect(self.download_progress)
 
-            # After asset download has finished load the asset
-            # if it can be loaded as QGIS map layer.
+            # After asset download has finished, load the asset
+            # if it can be loaded as a QGIS map layer.
             if load_asset and asset.type in layer_types:
                 asset.href = self.download_result["file"]
                 asset.title = title
-                asset.type = AssetLayerType.GEOTIFF.value
+                asset.type = AssetLayerType.GEOTIFF.value \
+                    if AssetLayerType.COG.value in asset.type else asset.type
                 load_file = partial(self.load_file_asset, asset)
                 feedback.progressChanged.connect(load_file)
 
@@ -220,7 +221,9 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             )
 
     def load_file_asset(self, asset, value):
-        """Loads the asset file into QGIS map canvas
+        """Loads the passed asset into QGIS map canvas if the
+        progress value indicates the download has finished.
+
         param asset: Item asset
         :type asset: models.ResourceAsset
 

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -177,6 +177,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         layer_types = [
             AssetLayerType.COG.value,
             AssetLayerType.GEOTIFF.value,
+            AssetLayerType.NETCDF.value,
         ]
         try:
             self.main_widget.show_message(
@@ -200,12 +201,12 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
 
             # After asset download has finished load the asset
             # if it can be loaded as QGIS map layer.
-            if load_asset and self.asset.type in layer_types:
-                self.asset.href = self.download_result["file"]
-                self.asset.title = title
+            if load_asset and asset.type in layer_types:
+                asset.href = self.download_result["file"]
+                asset.title = title
+                asset.type = AssetLayerType.GEOTIFF.value
                 load_file = partial(self.load_file_asset, asset)
                 feedback.progressChanged.connect(load_file)
-
 
             processing.run(
                 "qgis:filedownloader",
@@ -252,7 +253,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         :param filename: File name
         :type filename: str
         """
-        characters = " %:/,.\[]<>*?"
+        characters = " %:/,\[]<>*?"
 
         for character in characters:
             if character in filename:
@@ -273,8 +274,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         raster_types = ','.join([
             AssetLayerType.COG.value,
             AssetLayerType.GEOTIFF.value,
-            AssetLayerType.NETCDF.value,
-            AssetLayerType.X_NETCDF.value
+            AssetLayerType.NETCDF.value
         ])
         vector_types = ','.join([
             AssetLayerType.GEOJSON.value,

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -746,7 +746,7 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
             self.show_message(
                 tr(
                     'Download folder has not been set, '
-                   'a system temporary folder will be used'
+                    'a system temporary folder will be used'
                    ),
                 level=Qgis.Warning
             )


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/130

After the asset download has finished, these changes will enable auto loading of the asset into the QGIS map canvas if the asset is loadable as a QGIS map layer.
