### PR TITLE
Disable the sort buttons when searching the catalogs

### DIFF
--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -469,6 +469,9 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         self.extent_box.setEnabled(enabled)
         self.advanced_box.setEnabled(enabled)
         self.search_btn.setEnabled(enabled)
+        self.sort_by_la.setEnabled(enabled)
+        self.sort_cmb.setEnabled(enabled)
+        self.reverse_order_box.setEnabled(enabled)
 
     def prepare_message_bar(self):
         """ Initializes the widget message bar settings"""

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>917</width>
-    <height>869</height>
+    <height>977</height>
    </rect>
   </property>
   <property name="font">
@@ -423,7 +423,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QLabel" name="label_9">
+          <widget class="QLabel" name="sort_by_la">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
              <horstretch>0</horstretch>
@@ -645,8 +645,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>875</width>
-            <height>707</height>
+            <width>98</width>
+            <height>28</height>
            </rect>
           </property>
          </widget>


### PR DESCRIPTION
When searching is in process we need to disable the sort buttons and enable them once search has finished.