### PR TITLE
New asset loading setting

### DIFF
--- a/src/qgis_stac/conf.py
+++ b/src/qgis_stac/conf.py
@@ -5,9 +5,10 @@
 
 import contextlib
 import dataclasses
+import datetime
+import enum
 import typing
 import uuid
-import datetime
 
 from qgis.PyQt import (
     QtCore,
@@ -242,6 +243,9 @@ class ConformanceSettings(Conformance):
             name=settings.value("name"),
             uri=settings.value("uri")
         )
+
+class SettingName(enum.Enum):
+    AUTO_ASSET_LOADING = "auto_asset_loading"
 
 
 class SettingsManager(QtCore.QObject):

--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -17,6 +17,8 @@ from qgis.PyQt.uic import loadUiType
 
 from ..api.models import AssetLayerType
 
+from ..conf import SettingName, settings_manager
+
 from ..utils import tr
 
 WidgetUi, _ = loadUiType(
@@ -56,10 +58,16 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
             self.asset_dialog.load_asset,
             self.asset
         )
+        auto_asset_loading = settings_manager.get_value(
+            SettingName.AUTO_ASSET_LOADING,
+            False,
+            setting_type=bool
+        )
+
         download_asset = partial(
             self.asset_dialog.download_asset,
             self.asset,
-            True
+            auto_asset_loading
         )
         self.load_btn.setEnabled(self.asset.type in layer_types)
         self.load_btn.clicked.connect(load_asset)

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -17,7 +17,7 @@ from ..resources import *
 from ..gui.connection_dialog import ConnectionDialog
 from ..gui.collection_dialog import CollectionDialog
 
-from ..conf import settings_manager
+from ..conf import SettingName, settings_manager
 from ..api.models import (
     ItemSearch,
     FilterLang,
@@ -174,7 +174,28 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         self.items_filter.textChanged.connect(self.items_filter_changed)
 
         self.get_filters()
+        self.prepare_plugin_settings()
 
+    def prepare_plugin_settings(self):
+        """ Initializes all the plugin related settings"""
+
+        auto_asset_loading = settings_manager.get_value(
+            SettingName.AUTO_ASSET_LOADING,
+            False,
+            setting_type=bool
+        )
+        self.asset_loading.setChecked(auto_asset_loading)
+
+        self.asset_loading.toggled.connect(self.update_plugin_settings)
+
+    def update_plugin_settings(self):
+        """ Makes updates to all the plugin settings
+         defined in the settings tab
+         """
+        settings_manager.set_value(
+            SettingName.AUTO_ASSET_LOADING,
+            self.asset_loading.isChecked(),
+        )
     def prepare_filter_box(self):
         """ Prepares the advanced filter group box inputs"""
 

--- a/src/qgis_stac/ui/asset_widget.ui
+++ b/src/qgis_stac/ui/asset_widget.ui
@@ -63,7 +63,7 @@
      <item row="0" column="2">
       <widget class="QPushButton" name="download_btn">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Download the item asset into the filesystem. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Download the item asset into the filesystem. The asset can be loaded after download is finished if the related plugin setting is enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Download asset</string>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">
@@ -645,8 +645,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>98</width>
-            <height>28</height>
+            <width>875</width>
+            <height>815</height>
            </rect>
           </property>
          </widget>
@@ -811,6 +811,16 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="asset_loading">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting enables loading item assets that can be added into QGIS as map layers after dowloading them.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Enable loading assets after download</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
These changes include a new added setting in the plugin settings table that helps users to specify whether to load an asset after downloading it.

Screenshot of the settings tab UI including the new setting.
![image](https://user-images.githubusercontent.com/2663775/169817054-6ff7527d-cc66-4695-a551-c9df425e84b8.png)
