### PR TITLE
Minor UI updates to the search tab

### DIFF
--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -196,6 +196,7 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
             SettingName.AUTO_ASSET_LOADING,
             self.asset_loading.isChecked(),
         )
+
     def prepare_filter_box(self):
         """ Prepares the advanced filter group box inputs"""
 

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -29,7 +29,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="search">
       <attribute name="title">
@@ -234,7 +234,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="0" column="0">
@@ -322,7 +322,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -341,7 +341,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_12">
           <item>


### PR DESCRIPTION
Updates to the search tab date filter, spatial extent and advance group boxes. When the plugin is opened on the first time after install these groups should be collapsed. 