### PR TITLE
Remove duplicate collections entries.

### DIFF
--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -878,6 +878,8 @@ class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
         :param collections: List of collections to be added
         :type collections: []
         """
+        self.model.removeRows(0, self.model.rowCount())
+
         self.result_collections_la.setText(
             tr("{} STAC collection(s)").format(
                 len(collections)


### PR DESCRIPTION
These changes makes sure that the collection model is cleared out before populating the collection view with another list of the STAC collections.