### PR TITLE
Update layer types check when loading assets into QGIS 

### DIFF
--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -71,7 +71,7 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
             self.asset,
             auto_asset_loading
         )
-        self.load_btn.setEnabled(self.asset.type in layer_types)
+        self.load_btn.setEnabled(self.asset.type in ''.join(layer_types))
         self.load_btn.clicked.connect(load_asset)
         self.download_btn.clicked.connect(download_asset)
 

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -266,7 +266,6 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
 
         return filename
 
-
     def load_asset(self, asset):
         """ Loads asset into QGIS.
             Checks if the asset type is a loadable layer inside QGIS.

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -470,7 +470,7 @@ class LayerLoader(QgsTask):
         else:
             provider_error = tr("error {}").format(
                 self.layer.dataProvider().error()
-            )if self.layer else ""
+            )if self.layer and self.layer.dataProvider() else ""
             self.error = tr(
                 f"Couldn't load layer "
                 f"{self.layer_uri},"


### PR DESCRIPTION
This PR contains changes in the layer type check when loading asset as a layer in map canvas.