### PR TITLE
Result item UI update

### DIFF
--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -242,7 +242,7 @@ class Conformance:
 
 @dataclasses.dataclass
 class Item:
-    """ Represents the STAC API Item"""
+    """ Represents the plugin STAC API Item"""
     id: str = None
     item_uuid: UUID = uuid4()
     type: ResourceType = None

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -174,9 +174,10 @@ class ResourceProperties:
     resource_datetime: datetime.datetime = None
     created: datetime.datetime = None
     updated: datetime.datetime = None
-    start_datetime: datetime.datetime = None
-    end_datetime: datetime.datetime = None
+    start_date: datetime.datetime = None
+    end_date: datetime.datetime = None
     license: str = None
+    eo_cloud_cover: float = None
 
 
 @dataclasses.dataclass

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -252,11 +252,30 @@ class ContentFetcherTask(QgsTask):
             if self.api_capability == ApiCapability.SUPPORT_SAS_TOKEN:
                 item = pc.sign(item)
             try:
+                properties_datetime = item.properties.get("datetime")
+
                 item_datetime = parser.parse(
-                    item.properties.get("datetime"),
-                )
+                    properties_datetime
+                ) if properties_datetime else None
+
+                properties_start_date = item.properties.get("start_date")
+                start_date = parser.parse(
+                    properties_start_date,
+                ) if properties_start_date else None
+
+                properties_end_date = item.properties.get("end_date")
+
+                end_date = parser.parse(
+                    properties_end_date
+                ) if properties_end_date else None
+
+                cloud_cover = item.properties.get("eo:cloud_cover")
+
                 properties = ResourceProperties(
-                    resource_datetime=item_datetime
+                    resource_datetime=item_datetime,
+                    eo_cloud_cover=cloud_cover,
+                    start_date=start_date,
+                    end_date=end_date
                 )
             except Exception as e:
                 log(

--- a/src/qgis_stac/conf.py
+++ b/src/qgis_stac/conf.py
@@ -816,7 +816,7 @@ class SettingsManager(QtCore.QObject):
         :type identifier: str
 
         :param connection: Connection that the collection belongs to.
-        :type connection: str
+        :type connection: ConnectionSettings
         """
 
         settings_key = self._get_collection_settings_base(
@@ -828,6 +828,40 @@ class SettingsManager(QtCore.QObject):
                 str(identifier), settings
             )
         return collection_settings
+
+    def get_collection(self, collection_id, connection):
+        """ Retrieves the collection that matched the passed collection id
+
+        :param id: Collection id
+        :type id: str
+
+        :param connection: Connection that the collection belongs to.
+        :type connection: ConnectionSettings
+        """
+
+        connection_identifier = connection.id
+
+        result = []
+        with qgis_settings(
+                f"{self.BASE_GROUP_NAME}/"
+                f"{self.CONNECTION_GROUP_NAME}/"
+                f"{str(connection_identifier)}/"
+                f"{self.COLLECTION_GROUP_NAME}"
+        ) \
+                as settings:
+            for uuid in settings.childGroups():
+                collection_settings_key = self._get_collection_settings_base(
+                    connection_identifier,
+                    uuid
+                )
+                with qgis_settings(collection_settings_key) \
+                        as collection_settings:
+                    collection = CollectionSettings.from_qgs_settings(
+                            uuid, collection_settings
+                    )
+                    if collection.id == collection_id:
+                        return collection
+        return None
 
     def get_collections(self, connection_identifier):
         """ Gets all the available collections settings in the

--- a/src/qgis_stac/conf.py
+++ b/src/qgis_stac/conf.py
@@ -613,6 +613,9 @@ class SettingsManager(QtCore.QObject):
 
         :param identifier: Connection settings identifier
         :type identifier: uuid.UUID
+
+        :returns Connection settings base group
+        :rtype str
         """
         return f"{self.BASE_GROUP_NAME}/" \
                f"{self.CONNECTION_GROUP_NAME}/" \
@@ -630,6 +633,9 @@ class SettingsManager(QtCore.QObject):
 
         :param identifier: Collection settings identifier
         :type identifier: uuid.UUID
+
+        :returns Collection settings base group
+        :rtype str
         """
         return f"{self.BASE_GROUP_NAME}/" \
                f"{self.CONNECTION_GROUP_NAME}/" \
@@ -649,6 +655,9 @@ class SettingsManager(QtCore.QObject):
 
         :param identifier: Conformance settings identifier
         :type identifier: uuid.UUID
+
+        :returns Conformance settings base group
+        :rtype str
         """
         return f"{self.BASE_GROUP_NAME}/" \
                f"{self.CONNECTION_GROUP_NAME}/" \
@@ -662,7 +671,19 @@ class SettingsManager(QtCore.QObject):
             page,
             identifier
     ):
-        """Gets the items settings base url.
+        """Gets the items settings base group.
+
+        :param connection_identifier: Connection settings identifier
+        :type connection_identifier: uuid.UUID
+
+        :param page: The result page that the item was when fetched.
+        :type page: str
+
+        :param identifier: The item settings identifier
+        :type identifier: uuid.UUID
+
+        :returns Items settings base group
+        :rtype str
         """
         return f"{self.BASE_GROUP_NAME}/" \
                f"{self.CONNECTION_GROUP_NAME}/" \
@@ -810,13 +831,16 @@ class SettingsManager(QtCore.QObject):
                 settings.setValue("type", asset.type)
 
     def get_collection(self, identifier, connection):
-        """ Retrieves the collection with the identifier
+        """ Retrieves the collection that matches the passed identifier.
 
         :param identifier: Collection identifier
         :type identifier: str
 
         :param connection: Connection that the collection belongs to.
         :type connection: ConnectionSettings
+
+        :returns Collection settings instance
+        :rtype CollectionSettings
         """
 
         settings_key = self._get_collection_settings_base(
@@ -830,13 +854,16 @@ class SettingsManager(QtCore.QObject):
         return collection_settings
 
     def get_collection(self, collection_id, connection):
-        """ Retrieves the collection that matched the passed collection id
+        """ Retrieves the first collection that matched the passed collection id.
 
-        :param id: Collection id
-        :type id: str
+        :param collection_id: STAC collection id
+        :type collection_id: str
 
         :param connection: Connection that the collection belongs to.
         :type connection: ConnectionSettings
+
+        :returns Collection settings instance
+        :rtype CollectionSettings
         """
 
         connection_identifier = connection.id
@@ -870,6 +897,9 @@ class SettingsManager(QtCore.QObject):
         :param connection_identifier: Connection identifier from which
         to get all the available collections
         :type connection_identifier: uuid.UUID
+
+        :returns List of the collection settings instances
+        :rtype list
         """
         result = []
         with qgis_settings(
@@ -918,6 +948,9 @@ class SettingsManager(QtCore.QObject):
         :param connection_identifier: Connection identifier from which
         to get all the available collections
         :type connection_identifier: uuid.UUID
+
+        :returns List of the conformances settings instances
+        :rtype list
         """
         result = []
         with qgis_settings(
@@ -988,6 +1021,9 @@ class SettingsManager(QtCore.QObject):
 
         :param items_uuids: List of target items ids
         :type items_uuids: []
+
+        :returns List of the item settings instances
+        :rtype list
         """
         result = {}
         with qgis_settings(

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -97,6 +97,20 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
             datetime_str
         ) if datetime_str else None
 
+        if self.item.properties.eo_cloud_cover:
+            cloud_cover = round(self.item.properties.eo_cloud_cover, 2)
+
+            cloud_cover_integer = int(cloud_cover)
+
+            cloud_cover = cloud_cover_integer \
+                if cloud_cover == cloud_cover_integer else cloud_cover
+
+            self.cloud_cover.setText(
+                tr(
+                    "Cloud cover: {}%"
+                   ).format(cloud_cover)
+            )
+
         # Get item collection name if catalogs collections have been stored
         # in the plugin catalog connection settings.
         current_connection = settings_manager.get_current_connection()

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -76,9 +76,9 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
         self.setupUi(self)
         self.item = item
         self.title_la.setText(item.id)
-        self.collection_name.setText(item.collection)
         self.thumbnail_url = None
-        self.date_format = "%Y-%m-%dT%H:%M:%S"
+        self.date_time_format = "%Y-%m-%dT%H:%M:%S"
+        self.simple_date_format = "%m/%d/%Y"
         self.main_widget = main_widget
         self.layer_loader = None
         self.initialize_ui()
@@ -90,12 +90,26 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
 
         datetime_str = datetime.datetime.strftime(
             self.item.properties.resource_datetime,
-            self.date_format
-        ) if self.item.properties else ""
+            self.simple_date_format
+        ) if self.item.properties else None
 
         self.created_date.setText(
             datetime_str
+        ) if datetime_str else None
+
+        # Get item collection name if catalogs collections have been stored
+        # in the plugin catalog connection settings.
+        current_connection = settings_manager.get_current_connection()
+
+        collection = settings_manager.get_collection(
+            collection_id=self.item.collection,
+            connection=current_connection
         )
+
+        collection_label = collection.title \
+            if collection else self.item.collection
+        self.collection_name.setText(collection_label)
+
         thumbnail_url = None
         overview_url = None
 

--- a/src/qgis_stac/gui/result_item_widget.py
+++ b/src/qgis_stac/gui/result_item_widget.py
@@ -88,22 +88,44 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
     def initialize_ui(self):
         """ Populate UI inputs when loading the widget"""
 
-        datetime_str = datetime.datetime.strftime(
-            self.item.properties.resource_datetime,
-            self.simple_date_format
-        ) if self.item.properties else None
+        datetime_str = None
+        if self.item.properties and \
+            self.item.properties.start_date and \
+            self.item.proerties.end_date:
+
+            start_date = datetime.datetime.strftime(
+                self.item.properties.start_date,
+                self.simple_date_format
+            )
+            end_date = datetime.datetime.strftime(
+                self.item.properties.end_date,
+                self.simple_date_format
+            )
+
+            datetime_str = f"{start_date} - {end_date}"
+
+        elif self.item.properties and \
+                self.item.properties.resource_datetime:
+
+            datetime_str = datetime.datetime.strftime(
+                self.item.properties.resource_datetime,
+                self.simple_date_format
+            )
 
         self.created_date.setText(
             datetime_str
         ) if datetime_str else None
 
         if self.item.properties.eo_cloud_cover:
-            cloud_cover = round(self.item.properties.eo_cloud_cover, 2)
+            cloud_cover = round(
+                self.item.properties.eo_cloud_cover,
+                2)
 
             cloud_cover_integer = int(cloud_cover)
 
             cloud_cover = cloud_cover_integer \
-                if cloud_cover == cloud_cover_integer else cloud_cover
+                if cloud_cover == cloud_cover_integer \
+                else cloud_cover
 
             self.cloud_cover.setText(
                 tr(
@@ -136,12 +158,15 @@ class ResultItemWidget(QtWidgets.QWidget, WidgetUi):
 
         if overview_url:
             params = {
-                constants.THUMBNAIL_HEIGHT_PARAM: constants.THUMBNAIL_HEIGHT,
-                constants.THUMBNAIL_WIDTH_PARAM: constants.THUMBNAIL_WIDTH,
+                constants.THUMBNAIL_HEIGHT_PARAM:
+                    constants.THUMBNAIL_HEIGHT,
+                constants.THUMBNAIL_WIDTH_PARAM:
+                    constants.THUMBNAIL_WIDTH,
             }
             overview_url = self.append_url_params(overview_url, params)
 
-        self.thumbnail_url = thumbnail_url if thumbnail_url else overview_url
+        self.thumbnail_url = thumbnail_url \
+            if thumbnail_url else overview_url
 
         self.view_assets_btn.setEnabled(self.item.assets is not None)
         self.view_assets_btn.clicked.connect(self.open_assets_dialog)

--- a/src/qgis_stac/ui/result_item_widget.ui
+++ b/src/qgis_stac/ui/result_item_widget.ui
@@ -67,7 +67,7 @@
            </sizepolicy>
           </property>
           <property name="styleSheet">
-           <string notr="true">font-size: 18px; font-weight: 500;</string>
+           <string notr="true">font-size: 17px; font-weight: 500;</string>
           </property>
           <property name="frameShape">
            <enum>QFrame::NoFrame</enum>
@@ -95,7 +95,7 @@
            </sizepolicy>
           </property>
           <property name="styleSheet">
-           <string notr="true">font-size:16px; font-weight:310;</string>
+           <string notr="true">font-size:15px; font-weight:310;</string>
           </property>
           <property name="text">
            <string>Collection name</string>

--- a/src/qgis_stac/ui/result_item_widget.ui
+++ b/src/qgis_stac/ui/result_item_widget.ui
@@ -66,6 +66,9 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="styleSheet">
+           <string notr="true">font-size: 18px; font-weight: bold;</string>
+          </property>
           <property name="frameShape">
            <enum>QFrame::NoFrame</enum>
           </property>
@@ -74,6 +77,31 @@
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="collection_name">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">font-size:15px;</string>
+          </property>
+          <property name="text">
+           <string>Collection name</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -120,26 +148,17 @@
          </layout>
         </item>
         <item>
-         <widget class="QLabel" name="collection_name">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
           </property>
-          <property name="text">
-           <string>New description</string>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-          </property>
-         </widget>
+         </spacer>
         </item>
         <item>
          <layout class="QHBoxLayout" name="action_buttons_layout">

--- a/src/qgis_stac/ui/result_item_widget.ui
+++ b/src/qgis_stac/ui/result_item_widget.ui
@@ -67,7 +67,7 @@
            </sizepolicy>
           </property>
           <property name="styleSheet">
-           <string notr="true">font-size: 18px; font-weight: bold;</string>
+           <string notr="true">font-size: 18px; font-weight: 500;</string>
           </property>
           <property name="frameShape">
            <enum>QFrame::NoFrame</enum>
@@ -95,7 +95,7 @@
            </sizepolicy>
           </property>
           <property name="styleSheet">
-           <string notr="true">font-size:15px;</string>
+           <string notr="true">font-size:16px; font-weight:310;</string>
           </property>
           <property name="text">
            <string>Collection name</string>
@@ -121,6 +121,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="styleSheet">
+             <string notr="true">font-weight:200;</string>
+            </property>
             <property name="text">
              <string>Date acquired:</string>
             </property>
@@ -134,6 +137,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="styleSheet">
+             <string notr="true">font-weight:200;</string>
+            </property>
             <property name="text">
              <string/>
             </property>
@@ -146,6 +152,16 @@
            </widget>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="cloud_cover">
+          <property name="styleSheet">
+           <string notr="true">font-weight:300;</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
         </item>
         <item>
          <spacer name="verticalSpacer">


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/129

Updates the labels of the result item widget, including the eo:cloud_cover property and collection name if the the collection for the item has already been fetched by the plugin.

New look of the result items widgets
![image](https://user-images.githubusercontent.com/2663775/171802321-91dc939d-f051-41f3-aa1c-03d40711ed78.png)
