### PR TITLE
Support multiple assets loading and downloading

### DIFF
--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -31,6 +31,12 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
     assets loading and downloading functionalities
     """
 
+    load_selected = QtCore.pyqtSignal()
+    download_selected = QtCore.pyqtSignal()
+
+    load_deselected = QtCore.pyqtSignal()
+    download_deselected = QtCore.pyqtSignal()
+
     def __init__(
         self,
         asset,
@@ -56,28 +62,26 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
 
         self.title_la.setText(self.asset.title)
         self.type_la.setText(self.asset.type)
-        load_asset = partial(
-            self.asset_dialog.load_asset,
-            self.asset
-        )
-        auto_asset_loading = settings_manager.get_value(
-            Settings.AUTO_ASSET_LOADING,
-            False,
-            setting_type=bool
-        )
 
-        download_asset = partial(
-            self.asset_dialog.download_asset,
-            self.asset,
-            auto_asset_loading
-        )
-        self.load_btn.setEnabled(self.asset.type in ''.join(layer_types))
-        self.load_btn.clicked.connect(load_asset)
-        self.download_btn.clicked.connect(download_asset)
+        self.load_box.setEnabled(self.asset.type in ''.join(layer_types))
+        self.load_box.toggled.connect(self.asset_load_selected)
+        self.download_box.toggled.connect(self.asset_download_selected)
 
         if self.asset.type not in layer_types:
-            self.load_btn.setToolTip(
+            self.load_box.setToolTip(
                 tr("Asset contains a {} media type which "
                    "cannot be loaded as a map layer in QGIS"
                    ).format(self.asset.type)
             )
+
+    def asset_load_selected(self):
+        if self.load_box.isChecked():
+            self.load_selected.emit()
+        else:
+            self.load_deselected.emit()
+
+    def asset_download_selected(self):
+        if self.download_box.isChecked():
+            self.download_selected.emit()
+        else:
+            self.download_deselected.emit()

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -50,7 +50,7 @@ WidgetUi, _ = loadUiType(
 )
 
 
-class QgisStacWidget(QtWidgets.QDialog, WidgetUi):
+class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
     """ Main plugin widget that contains tabs for search, results and settings
     functionalities"""
 

--- a/src/qgis_stac/main.py
+++ b/src/qgis_stac/main.py
@@ -13,9 +13,9 @@ import re
 import os.path
 
 from qgis.core import QgsSettings
-from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication
+from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication, Qt
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QAction
+from qgis.PyQt.QtWidgets import QAction, QDockWidget, QMainWindow
 
 # Initialize Qt resources from file resources.py
 from .resources import *
@@ -48,6 +48,11 @@ class QgisStac:
         self.main_widget = QgisStacWidget()
         self.toolbar = self.iface.addToolBar("Open STAC API Browser")
         self.toolbar.setObjectName("QGISStac")
+
+        self.main_window = QMainWindow()
+        self.main_window.setWindowTitle("STAC API Browser")
+        self.main_window.resize(850, 1000)
+        self.main_window.setCentralWidget(self.main_widget)
 
         # Add default catalogs, first check if they have already
         # been set.
@@ -182,6 +187,6 @@ class QgisStac:
             self.iface.removeToolBarIcon(action)
 
     def run(self):
-        self.main_widget.show()
+        self.main_window.show()
         if not self.pluginIsActive:
             self.pluginIsActive = True

--- a/src/qgis_stac/ui/asset_widget.ui
+++ b/src/qgis_stac/ui/asset_widget.ui
@@ -39,17 +39,24 @@
     <number>5</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout" columnminimumwidth="5,5,5,5">
+    <layout class="QGridLayout" name="gridLayout">
      <property name="sizeConstraint">
       <enum>QLayout::SetDefaultConstraint</enum>
      </property>
-     <item row="0" column="3">
-      <widget class="QPushButton" name="download_btn">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Download the item asset into the filesystem. The asset can be loaded after download is finished if the related plugin setting is enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="title_la">
        <property name="text">
-        <string>Download asset</string>
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QCheckBox" name="load_box">
+       <property name="text">
+        <string>Select to add as a layer</string>
        </property>
       </widget>
      </item>
@@ -63,23 +70,10 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="load_btn">
-       <property name="toolTip">
-        <string>Load asset as a layer</string>
-       </property>
+     <item row="0" column="3">
+      <widget class="QCheckBox" name="download_box">
        <property name="text">
-        <string>Add asset as layer</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="title_la">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
+        <string>Select to download</string>
        </property>
       </widget>
      </item>

--- a/src/qgis_stac/ui/item_assets_widget.ui
+++ b/src/qgis_stac/ui/item_assets_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>920</width>
-    <height>288</height>
+    <width>1012</width>
+    <height>485</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,6 +18,16 @@
     <widget class="QLabel" name="title">
      <property name="styleSheet">
       <string notr="true">font: 14pt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="asset_count">
+     <property name="styleSheet">
+      <string notr="true">font-size: 15px; font-weight: 300;</string>
      </property>
      <property name="text">
       <string/>
@@ -52,15 +62,15 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
-      <widget class="QLabel" name="label_6">
+     <item row="0" column="2">
+      <widget class="QLabel" name="label_5">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="label_5">
+     <item row="0" column="3">
+      <widget class="QLabel" name="label_6">
        <property name="text">
         <string/>
        </property>
@@ -103,12 +113,68 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>900</width>
-        <height>189</height>
+        <width>992</width>
+        <height>304</height>
        </rect>
       </property>
      </widget>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="load_btn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Loads the selected assets as layers.</string>
+       </property>
+       <property name="text">
+        <string>Add assets as layers</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="download_btn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Downloads the select assets into the filesystem. The asset can be loaded after download is finished if the related plugin setting is enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Download the assets</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Implemented the support for multiple loading of assets as layers and assets downloading.

These changes also contain updates that include the minimize and maximize button in plugin main widget.

Screenshot of the multiple assets loading
![multiple_assets_loading](https://user-images.githubusercontent.com/2663775/172266270-0cab0f55-8939-48fc-99ed-585719acc619.gif)
