### PR TITLE
Add support for queryables filtering

### DIFF
--- a/src/qgis_stac/api/base.py
+++ b/src/qgis_stac/api/base.py
@@ -13,9 +13,10 @@ from .models import (
     ItemSearch,
     ResourcePagination,
     ResourceType,
+    Queryable
 )
 
-from .network import ContentFetcherTask
+from .network import ContentFetcherTask, NetworkFetcher
 from ..conf import ConnectionSettings
 
 from ..lib.pystac import ItemCollection
@@ -47,6 +48,9 @@ class BaseClient(QtCore.QObject):
     item_collections_received = QtCore.pyqtSignal(
         ItemCollection
     )
+
+    queryable_received = QtCore.pyqtSignal(Queryable)
+
     error_received = QtCore.pyqtSignal([str], [str, int, str])
 
     def __init__(
@@ -137,6 +141,23 @@ class BaseClient(QtCore.QObject):
 
         QgsApplication.taskManager().addTask(self.content_task)
 
+    def get_queryable(
+        self,
+        fetch_type,
+        resource=None
+    ):
+        """Fetches the queryable properties in the STAC API.
+        """
+        network_fetcher = NetworkFetcher(
+            url=self.url,
+            response_handler=self.handle_queryable,
+            error_handler=self.handle_error,
+        )
+        network_fetcher.get_queryable(
+            fetch_type=fetch_type,
+            resource=resource
+        )
+
     def handle_conformance(
             self,
             conformance,
@@ -164,8 +185,16 @@ class BaseClient(QtCore.QObject):
     ):
         raise NotImplementedError
 
+    def handle_queryable(
+            self,
+            queryable
+    ):
+        raise NotImplementedError
+
     def handle_error(
             self,
             message: str
     ):
         raise NotImplementedError
+
+

--- a/src/qgis_stac/api/client.py
+++ b/src/qgis_stac/api/client.py
@@ -77,6 +77,17 @@ class Client(BaseClient):
         """
         self.conformance_received.emit(conformance, pagination)
 
+    def handle_queryable(
+            self,
+            queryable
+    ):
+        """Emits the fetched queryable properties classes from the API.
+
+        :param queryable: Queryable properties
+        :type queryable: dict
+        """
+        self.queryable_received.emit(queryable)
+
     def handle_error(
             self,
             message: str

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -356,13 +356,15 @@ class ItemSearch:
             datetime_str = f"{self.start_datetime.toString(QtCore.Qt.ISODate)}/" \
                            f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
 
-        method = 'GET'
-        text = self.filter_text
+        method = 'POST'
+        text = None
 
-        if self.filter_text and \
-            self.filter_lang != FilterLang.CQL2_TEXT:
-            text = json.loads(self.filter_text)
-            method = 'POST'
+        if self.filter_text:
+            if self.filter_lang == FilterLang.CQL2_TEXT:
+                method = 'GET'
+                text = self.filter_text
+            else:
+                text = json.loads(self.filter_text)
 
         filter_lang_values = {
             FilterLang.CQL_JSON: 'cql-json',

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -7,7 +7,6 @@ https://github.com/radiantearth/stac-api-spec/tree/master/stac-spec
 
 """
 
-
 import dataclasses
 import datetime
 import enum
@@ -74,9 +73,18 @@ class FilterLang(enum.Enum):
     STAC API item search
     """
     CQL_TEXT = 'CQL_TEXT'
+    CQL2_TEXT = 'CQL_TEXT'
     CQL_JSON = 'CQL_JSON'
     CQL2_JSON = 'CQL2_JSON'
     STAC_QUERY = 'STAC_QUERY'
+
+
+class QueryablePropertyType(enum.Enum):
+    """ Represents STAC queryable property types."""
+    INTEGER = 'integer'
+    STRING = 'string'
+    OBJECT = 'object'
+    ENUM = 'enum'
 
 
 class SortField(enum.Enum):
@@ -123,6 +131,13 @@ class ResourceType(enum.Enum):
     FEATURE = "Feature"
     CATALOG = "Catalog"
     CONFORMANCE = "Conformance"
+
+
+class QueryableFetchType(enum.Enum):
+    """Queryable fetch types"""
+    CATALOG = "Catalog"
+    COLLECTION = "Collection"
+    COLLECTIONS = "Collections"
 
 
 @dataclasses.dataclass
@@ -198,6 +213,36 @@ class ResourceGeometry:
     """The GeoJSON geometry footprint STAC API assets"""
     type: GeometryType
     coordinates: typing.List[typing.List[int]]
+
+
+@dataclasses.dataclass
+class QueryableProperty:
+    """Represents the STAC API queryable properties, from
+    https://github.com/radiantearth/stac-api-spec/blob/master/
+    fragments/filter/README.md#queryables
+    """
+    name: str
+    title: str
+    type: str
+    ref: str
+    description: str
+    minimum: str
+    maximum: str
+    values: list
+
+
+@dataclasses.dataclass
+class Queryable:
+    """Represents the STAC API queryable properties, defined from
+    https://github.com/radiantearth/stac-api-spec/blob/master/
+    fragments/filter/README.md#queryables
+    """
+    schema: str = None
+    id: str = None
+    type: str = None
+    title: str = None
+    description: str = None
+    properties: typing.List[QueryableProperty] = None
 
 
 @dataclasses.dataclass
@@ -301,12 +346,18 @@ class ItemSearch:
             datetime_str = f"{self.start_datetime.toString(QtCore.Qt.ISODate)}/" \
                            f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
 
-        text = json.loads(self.filter_text) if self.filter_text else None
+        method = 'GET'
+        text = self.filter_text
+
+        if self.filter_text and \
+            self.filter_lang != FilterLang.CQL2_TEXT:
+            text = json.loads(self.filter_text)
+            method = 'POST'
 
         filter_lang_values = {
             FilterLang.CQL_JSON: 'cql-json',
             FilterLang.CQL2_JSON: 'cql2-json',
-            FilterLang.CQL_TEXT: 'cql-text'
+            FilterLang.CQL2_TEXT: 'cql2-text'
         }
 
         filter_lang_text = filter_lang_values[self.filter_lang] \
@@ -314,7 +365,11 @@ class ItemSearch:
 
         filter_text = text \
             if self.filter_lang in \
-               [FilterLang.CQL_JSON, FilterLang.CQL2_JSON] else None
+               [FilterLang.CQL_JSON,
+                FilterLang.CQL2_JSON,
+                FilterLang.CQL2_TEXT
+                ] else None
+
         query_text = text \
             if self.filter_lang == FilterLang.STAC_QUERY else None
 
@@ -335,9 +390,13 @@ class ItemSearch:
             }
         ] if self.sortby else []
 
+        from ..utils import log
+        log(f'Sent filter {filter_text}')
+
         parameters = {
             "ids": self.ids,
             "collections": self.collections or None,
+            "method": method,
             "limit": self.page_size,
             "bbox": bbox,
             "datetime": datetime_str,

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -79,13 +79,23 @@ class FilterLang(enum.Enum):
     STAC_QUERY = 'STAC_QUERY'
 
 
+class FilterOperator(enum.Enum):
+    """ Filter text operators.
+    """
+    LESS_THAN = '<'
+    GREATER_THAN = '>'
+    LESS_THAN_EQUAL = '<='
+    GREATER_THAN_EQUAL = '>='
+    EQUAL = '='
+
+
 class QueryablePropertyType(enum.Enum):
     """ Represents STAC queryable property types."""
     INTEGER = 'integer'
     STRING = 'string'
     OBJECT = 'object'
     ENUM = 'enum'
-
+    DATETIME = 'datetime'
 
 class SortField(enum.Enum):
     """ Holds the field value used when sorting items results."""

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -400,9 +400,6 @@ class ItemSearch:
             }
         ] if self.sortby else []
 
-        from ..utils import log
-        log(f'Sent filter {filter_text}')
-
         parameters = {
             "ids": self.ids,
             "collections": self.collections or None,

--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -497,10 +497,12 @@ class NetworkFetcher(QtCore.QObject):
         queryable_properties = data.get('properties', {})
 
         for key, value in queryable_properties.items():
-            enum_value = value.get('enum')
+            enum_values = value.get('enum')
             property_type = value.get('type')
-            if enum_value:
+            if enum_values:
                 property_type = 'enum'
+            if key == 'datetime':
+                property_type = 'datetime'
 
             queryable_property = QueryableProperty(
                 name=key,
@@ -510,7 +512,7 @@ class NetworkFetcher(QtCore.QObject):
                 type=property_type,
                 minimum=value.get('minimum'),
                 maximum=value.get('maximum'),
-                values=value.get('enum')
+                values=enum_values
             )
             properties.append(queryable_property)
 

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -211,6 +211,8 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.populate_queryable_field()
 
         self.fetch_queryable_btn.clicked.connect(self.fetch_queryable)
+        self.clear_properties_btn.clicked.connect(self.clear_properties)
+
         self.queryable_property_widgets = []
         self.queryable_properties = []
 
@@ -408,6 +410,15 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             # self.handle_queryable(Queryable())
 
         self.search_btn.setEnabled(current_connection is not None)
+
+    def clear_properties(self):
+        """ Removes all the current queryable properties from the
+        queryable group box
+        """
+
+        self.queryable_properties = []
+        self.queryable_property_widgets = []
+        self.queryable_area.setWidget(QtWidgets.QWidget())
 
     def fetch_queryable(self):
         """ Gets the queryable property using the plugin API."""
@@ -739,6 +750,13 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         )
 
     def collections_tree_double_clicked(self, index):
+        """ Opens the collection dialog when an entry from the
+        collections view tree has been double clicked.
+
+        :param index: Index of the double clicked item.
+        :type index: int
+
+        """
         collection = self.collections_tree.model().data(index, 1)
         collection_dialog = CollectionDialog(collection)
         collection_dialog.exec_()

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -19,6 +19,7 @@ from ..resources import *
 
 from ..gui.connection_dialog import ConnectionDialog
 from ..gui.collection_dialog import CollectionDialog
+from ..gui.queryable_property import QueryablePropertyWidget
 
 from ..conf import ConnectionSettings, Settings, settings_manager
 
@@ -30,6 +31,7 @@ from ..api.models import (
     SortField,
     SortOrder,
     TimeUnits,
+    QueryableFetchType
 )
 from ..api.client import Client
 
@@ -206,6 +208,10 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         )
 
         self.update_sas_frequency()
+        self.populate_queryable_field()
+
+        self.fetch_queryable_btn.clicked.connect(self.fetch_queryable)
+        self.queryable_property_widgets = []
 
     def prepare_plugin_settings(self):
         """ Initializes all the plugin related settings"""
@@ -398,8 +404,59 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             )
             self.model.removeRows(0, self.model.rowCount())
             self.load_collections(collections)
+            # self.handle_queryable(Queryable())
 
         self.search_btn.setEnabled(current_connection is not None)
+
+    def fetch_queryable(self):
+        self.current_progress_message = tr(
+            "Fetching queryable properties..."
+        )
+        self.search_started.emit()
+
+        queryable_fetch_type = self.queryable_fetch_cmb.itemData(
+            self.queryable_fetch_cmb.currentIndex()
+        )
+
+        if queryable_fetch_type == QueryableFetchType.COLLECTION:
+            for collection in self.get_selected_collections():
+                self.api_client.get_queryable(
+                    fetch_type=queryable_fetch_type,
+                    resource=collection
+                )
+        else:
+            self.api_client.get_queryable(
+                fetch_type=queryable_fetch_type
+            )
+
+    def handle_queryable(self, queryable):
+
+        scroll_container = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(1, 1, 1, 1)
+        layout.setSpacing(1)
+
+        scroll_container.setLayout(layout)
+
+        for property in queryable.properties:
+            property_widget = QueryablePropertyWidget(
+                property
+            )
+            layout.addWidget(property_widget)
+            layout.setAlignment(property_widget, QtCore.Qt.AlignTop)
+            self.queryable_property_widgets.append(property_widget)
+
+        self.queryable_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.queryable_area.setWidgetResizable(True)
+        self.queryable_area.setWidget(scroll_container)
+
+        if len(queryable.properties) < 0:
+            label = QtWidgets.QLabel(tr("No queryable properties found."))
+            layout.addWidget(label)
+
+        self.search_completed.emit()
+
+        log(f"returned {vars(queryable)}")
 
     def update_api_client(self):
         """
@@ -414,6 +471,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             if self.api_client:
                 self.api_client.items_received.connect(self.display_results)
                 self.api_client.collections_received.connect(self.display_results)
+                self.api_client.queryable_received.connect(self.handle_queryable)
                 self.api_client.error_received.connect(self.display_search_error)
 
     def update_connections_box(self):
@@ -488,6 +546,16 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         filter_lang = self.filter_lang_cmb.itemData(
             self.filter_lang_cmb.currentIndex()
         ) if self.advanced_box.isChecked() else None
+
+        if self.queryable_box.isChecked():
+            filter_texts = []
+            for property_widget in self.queryable_property_widgets:
+                filter_texts.append(property_widget.filter_text())
+            filter_text = ' and '.join(filter_texts)
+            filter_lang = FilterLang.CQL2_TEXT
+
+            log(f"filter text - {filter_text}")
+            log(f"filter lang {filter_lang}")
 
         sort_field = self.sort_cmb.itemData(
             self.sort_cmb.currentIndex()
@@ -591,7 +659,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
     def update_search_inputs(self, enabled):
         """ Sets the search inputs state using the provided enabled status
 
-        :param enabled: Whether to enable the inputs
+        :param enabled: Whether to enable the widgets.
         :type enabled: bool
         """
         self.connections_group.setEnabled(enabled)
@@ -599,6 +667,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.date_filter_group.setEnabled(enabled)
         self.extent_box.setEnabled(enabled)
         self.advanced_box.setEnabled(enabled)
+        self.queryable_box.setEnabled(enabled)
         self.search_btn.setEnabled(enabled)
         self.sort_by_la.setEnabled(enabled)
         self.sort_cmb.setEnabled(enabled)
@@ -891,7 +960,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         :param filter_text: Filter text
         :type: str
         """
-        # TODO update to user QtCore.QRegExp, QRegularExpression will be
+        # TODO update to use QtCore.QRegExp, QRegularExpression will be
         # deprecated.
         options = QtCore.QRegularExpression.NoPatternOption
         options |= QtCore.QRegularExpression.CaseInsensitiveOption
@@ -915,6 +984,17 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         for ordering_type, item_text in labels.items():
             self.sort_cmb.addItem(item_text, ordering_type)
         self.sort_cmb.setCurrentIndex(0)
+
+    def populate_queryable_field(self):
+        """" Initializes queryable field combo box list items"""
+        labels = {
+            QueryableFetchType.CATALOG: tr("Fetch from Catalog"),
+            QueryableFetchType.COLLECTION:
+                tr("Fetch from current selected collections"),
+        }
+        for queryable_type, item_text in labels.items():
+            self.queryable_fetch_cmb.addItem(item_text, queryable_type)
+        self.queryable_fetch_cmb.setCurrentIndex(0)
 
     def get_selected_collections(self, title=False):
         """ Gets the currently selected collections from the collection

--- a/src/qgis_stac/gui/queryable_property.py
+++ b/src/qgis_stac/gui/queryable_property.py
@@ -5,7 +5,7 @@
 
 import os
 
-from functools import partial
+from qgis.gui import QgsDateTimeEdit
 
 from qgis.PyQt import (
     QtGui,
@@ -15,9 +15,8 @@ from qgis.PyQt import (
 )
 from qgis.PyQt.uic import loadUiType
 
-from ..api.models import QueryablePropertyType
+from ..api.models import FilterOperator, QueryablePropertyType
 
-from ..conf import Settings, settings_manager
 
 from ..utils import tr
 
@@ -45,7 +44,14 @@ class QueryablePropertyWidget(QtWidgets.QWidget, WidgetUi):
     def initialize_ui(self):
         """ Populate UI inputs when loading the widget"""
 
+        size_policy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Preferred,
+            QtWidgets.QSizePolicy.Preferred,
+        )
+
         label = QtWidgets.QLabel(self.queryable_property.name)
+        label.setSizePolicy(size_policy)
+
         label_layout = QtWidgets.QVBoxLayout(self.property_label)
         label_layout.setContentsMargins(9, 9, 9, 9)
         label_layout.addWidget(label)
@@ -61,37 +67,88 @@ class QueryablePropertyWidget(QtWidgets.QWidget, WidgetUi):
                 self.queryable_property.maximum or 100
             )
             spin_box.setSingleStep(1)
+            spin_box.setSizePolicy(size_policy)
+
             input_layout.addWidget(spin_box)
             self.input_widget = spin_box
         elif self.queryable_property.type == \
             QueryablePropertyType.ENUM.value:
 
             cmb_box = QtWidgets.QComboBox()
-            self.cmb_cmb.addItem("")
+            cmb_box.setSizePolicy(size_policy)
+
+            cmb_box.addItem("")
             for enum_value in self.queryable_property.values:
-                self.cmb_box.addItem(enum_value, enum_value)
-            self.cmb_box.setCurrentIndex(0)
+                cmb_box.addItem(enum_value, enum_value)
+            cmb_box.setCurrentIndex(0)
 
             input_layout.addWidget(cmb_box)
             self.input_widget = cmb_box
+        elif self.queryable_property.type == \
+            QueryablePropertyType.DATETIME.value:
+
+            datetime_edit = QgsDateTimeEdit()
+            datetime_edit.setSizePolicy(size_policy)
+
+            input_layout.addWidget(datetime_edit)
+            self.input_widget = datetime_edit
         else:
             line_edit = QtWidgets.QLineEdit()
+            line_edit.setSizePolicy(size_policy)
+
             input_layout.addWidget(line_edit)
             self.input_widget = line_edit
+
+        labels = {
+            FilterOperator.LESS_THAN: tr("<"),
+            FilterOperator.GREATER_THAN: tr(">"),
+            FilterOperator.LESS_THAN_EQUAL: tr("<="),
+            FilterOperator.GREATER_THAN_EQUAL: tr(">="),
+            FilterOperator.EQUAL: tr("="),
+        }
+        self.operator_cmb.addItem("")
+        for operator, label in labels.items():
+            self.operator_cmb.addItem(label, operator)
+        self.operator_cmb.setCurrentIndex(0)
 
     def filter_text(self):
         """ Returns a cql-text representation of the property and the
         available value."""
 
-        if isinstance(self.input_widget, QtWidgets.QSpinBox):
+        try:
+            current_operator = self.operator_cmb.itemData(
+                self.operator_cmb.currentIndex()
+            ) if self.operator_cmb.currentIndex() != 0 else FilterOperator.EQUAL
 
-            text = f"{self.queryable_property.name} = " \
-                   f"{self.input_widget.value()}"
-        elif isinstance(self.input_widget, QtWidgets.QLineEdit):
-            text = f"{self.queryable_property.name} = " \
-                   f"{self.input_widget.text()}"
-        else:
-            raise NotImplementedError
+            if isinstance(self.input_widget, QtWidgets.QSpinBox) and \
+                    self.input_widget.value() != "":
+
+                text = f"{self.queryable_property.name} " \
+                       f"{current_operator.value} " \
+                       f"{self.input_widget.value()}"
+            elif isinstance(self.input_widget, QtWidgets.QLineEdit) and \
+                    self.input_widget.text() != "":
+                text = f"{self.queryable_property.name} " \
+                       f"{current_operator.value} " \
+                       f"{self.input_widget.text()}"
+            elif isinstance(self.input_widget, QtWidgets.QComboBox):
+                input_value = self.input_widget.itemData(
+                    self.input_widget.currentIndex()
+                )
+                text = f"{self.queryable_property.name} " \
+                       f"{current_operator.value} " \
+                       f"{input_value}" if input_value else None
+            elif isinstance(self.input_widget, QgsDateTimeEdit) and \
+                    not self.input_widget.isNull():
+                datetime_str = self.input_widget.dateTime().\
+                    toString(QtCore.Qt.ISODate)
+                text = f"{self.queryable_property.name} " \
+                       f"{current_operator.value} " \
+                       f"TIMESTAMP('{datetime_str}')"
+            else:
+                raise NotImplementedError
+        except RuntimeError as e:
+            text = None
 
         return text
 

--- a/src/qgis_stac/gui/queryable_property.py
+++ b/src/qgis_stac/gui/queryable_property.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""
+    Queryable property widget, used as a template for each property.
+"""
+
+import os
+
+from functools import partial
+
+from qgis.PyQt import (
+    QtGui,
+    QtCore,
+    QtWidgets,
+    QtNetwork
+)
+from qgis.PyQt.uic import loadUiType
+
+from ..api.models import QueryablePropertyType
+
+from ..conf import Settings, settings_manager
+
+from ..utils import tr
+
+WidgetUi, _ = loadUiType(
+    os.path.join(os.path.dirname(__file__), "../ui/queryable_property.ui")
+)
+
+
+class QueryablePropertyWidget(QtWidgets.QWidget, WidgetUi):
+    """ Widget that provide UI for STAC queryable properties details.
+    """
+
+    def __init__(
+        self,
+        queryable_property,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.queryable_property = queryable_property
+
+        self.input_widget = None
+        self.initialize_ui()
+
+    def initialize_ui(self):
+        """ Populate UI inputs when loading the widget"""
+
+        label = QtWidgets.QLabel(self.queryable_property.name)
+        label_layout = QtWidgets.QVBoxLayout(self.property_label)
+        label_layout.setContentsMargins(9, 9, 9, 9)
+        label_layout.addWidget(label)
+
+        input_layout = QtWidgets.QVBoxLayout(self.property_input)
+        input_layout.setContentsMargins(4, 4, 4, 4)
+
+        if self.queryable_property.type == \
+            QueryablePropertyType.INTEGER.value:
+            spin_box = QtWidgets.QSpinBox()
+            spin_box.setRange(
+                self.queryable_property.minimum or 1,
+                self.queryable_property.maximum or 100
+            )
+            spin_box.setSingleStep(1)
+            input_layout.addWidget(spin_box)
+            self.input_widget = spin_box
+        elif self.queryable_property.type == \
+            QueryablePropertyType.ENUM.value:
+
+            cmb_box = QtWidgets.QComboBox()
+            self.cmb_cmb.addItem("")
+            for enum_value in self.queryable_property.values:
+                self.cmb_box.addItem(enum_value, enum_value)
+            self.cmb_box.setCurrentIndex(0)
+
+            input_layout.addWidget(cmb_box)
+            self.input_widget = cmb_box
+        else:
+            line_edit = QtWidgets.QLineEdit()
+            input_layout.addWidget(line_edit)
+            self.input_widget = line_edit
+
+    def filter_text(self):
+        """ Returns a cql-text representation of the property and the
+        available value."""
+
+        if isinstance(self.input_widget, QtWidgets.QSpinBox):
+
+            text = f"{self.queryable_property.name} = " \
+                   f"{self.input_widget.value()}"
+        elif isinstance(self.input_widget, QtWidgets.QLineEdit):
+            text = f"{self.queryable_property.name} = " \
+                   f"{self.input_widget.text()}"
+        else:
+            raise NotImplementedError
+
+        return text
+
+

--- a/src/qgis_stac/main.py
+++ b/src/qgis_stac/main.py
@@ -51,7 +51,7 @@ class QgisStac:
 
         self.main_window = QMainWindow()
         self.main_window.setWindowTitle("STAC API Browser")
-        self.main_window.resize(850, 1000)
+        self.main_window.resize(850, 800)
         self.main_window.setCentralWidget(self.main_widget)
 
         # Add default catalogs, first check if they have already

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>995</width>
-    <height>695</height>
+    <width>911</width>
+    <height>842</height>
    </rect>
   </property>
   <property name="font">
@@ -408,6 +408,156 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="queryable_box">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use queryable properties to filter the catalog when searching.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="title">
+          <string>Data driven queryable</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <property name="collapsed">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_8">
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="toolTip">
+             <string>These properties are fetched from the '/queryables' catalog endpoint.</string>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">font-size:14px; font-weight: 400;</string>
+            </property>
+            <property name="text">
+             <string>Queryable properties that are available in the current catalog can be used as filters when searching.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_14">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="gridLayout">
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="title_la">
+              <property name="text">
+               <string>Property</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="type_la">
+              <property name="text">
+               <string>Input</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QScrollArea" name="queryable_area">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="widgetResizable">
+             <bool>true</bool>
+            </property>
+            <widget class="QWidget" name="scrollAreaWidgetContents_2">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>847</width>
+               <height>68</height>
+              </rect>
+             </property>
+            </widget>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <item>
+             <widget class="QPushButton" name="fetch_queryable_btn">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Fetch properties</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="queryable_fetch_cmb">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_13">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_12">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <spacer name="horizontalSpacer_8">
@@ -476,35 +626,12 @@
         </layout>
        </item>
        <item>
-        <spacer name="horizontalSpacer_10">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_9">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -645,8 +772,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>953</width>
-            <height>500</height>
+            <width>869</width>
+            <height>647</height>
            </rect>
           </property>
          </widget>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -234,7 +234,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="0" column="0">
@@ -469,13 +469,20 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
+            <item row="0" column="2">
              <widget class="QLabel" name="type_la">
               <property name="text">
                <string>Input</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="label_6">
+              <property name="text">
+               <string/>
               </property>
              </widget>
             </item>

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>911</width>
-    <height>842</height>
+    <width>906</width>
+    <height>781</height>
    </rect>
   </property>
   <property name="font">
@@ -234,7 +234,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="0" column="0">
@@ -413,7 +413,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use queryable properties to filter the catalog when searching.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="title">
-          <string>Data driven queryable</string>
+          <string>Data driven queryables</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -422,7 +422,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_8">
           <item>
@@ -501,8 +501,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>847</width>
-               <height>68</height>
+               <width>853</width>
+               <height>94</height>
               </rect>
              </property>
             </widget>
@@ -558,6 +558,16 @@
                </size>
               </property>
              </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="clear_properties_btn">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clear the list of the current queryable properties, should be used when new properties are needed to replace the current properties.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Clear</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>

--- a/src/qgis_stac/ui/queryable_property.ui
+++ b/src/qgis_stac/ui/queryable_property.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QueryablePropertyWidget</class>
+ <widget class="QWidget" name="QueryablePropertyWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>658</width>
+    <height>89</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>222</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Asset</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item row="0" column="1">
+      <widget class="QFrame" name="property_input">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QFrame" name="property_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qgis_stac/ui/queryable_property.ui
+++ b/src/qgis_stac/ui/queryable_property.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>658</width>
-    <height>89</height>
+    <width>649</width>
+    <height>37</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,7 +43,7 @@
      <property name="sizeConstraint">
       <enum>QLayout::SetDefaultConstraint</enum>
      </property>
-     <item row="0" column="1">
+     <item row="0" column="2">
       <widget class="QFrame" name="property_input">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -52,7 +52,7 @@
         </sizepolicy>
        </property>
        <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
+        <enum>QFrame::NoFrame</enum>
        </property>
        <property name="frameShadow">
         <enum>QFrame::Raised</enum>
@@ -68,27 +68,27 @@
         </sizepolicy>
        </property>
        <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
+        <enum>QFrame::NoFrame</enum>
        </property>
        <property name="frameShadow">
         <enum>QFrame::Raised</enum>
        </property>
       </widget>
      </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="operator_cmb">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Operator to be used when filtering, defaults to equal operator.</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
These changes contain support for using STAC queryables properties for filtering in the plugin.
The queryables are fetched based on thei definition in https://github.com/radiantearth/stac-api-spec/blob/master/fragments/filter/README.md#queryables.
Currently the pystac-client library does not have an API for getting the queryable properties see https://github.com/stac-utils/pystac-client/issues/231, so this implementation doesn't use the pystac-client API instead we have added a new class `NetworkFetcher` that will be responsible for fetching all the resources that cannot be fetched via the pystac-client library.

The plugin search tab now contains a new group box `Data driven queryables` that is responsible for fetching and setting values for the queryable properties.

Data drive queryables box
![image](https://user-images.githubusercontent.com/2663775/173025939-bb4be4d1-9662-43df-b104-6c2b65294f79.png)

`Fetch properties` button is for fetching the queryable properties, users can set to fetch the queryables from the Catalog root or the using the current selected collections from the collection list by selecting either `Fetch from Catalog` and `Fetch from current selected collections` respectively.

The plugin converts the quearyable properties to a `cql2-text` filter before submitting the filter to the corresponding STAC catalog API using the pystac-client.


Example using datetime queryable property to filter search results

![data_driven_filtering](https://user-images.githubusercontent.com/2663775/173026567-8d916401-2f33-4d87-ba19-8c86916609d5.gif)

