### PR TITLE
Remove search results items signing for SAS based connections.

### DIFF
--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -302,19 +302,19 @@ class ContentFetcherTask(QgsTask):
         # exists use it instead of the environment one.
         connection = settings_manager.get_current_connection()
 
-        if connection and \
-            connection.capability == ApiCapability.SUPPORT_SAS_TOKEN and \
-                connection.sas_subscription_key:
-            key = connection.sas_subscription_key
+        # if connection and \
+        #     connection.capability == ApiCapability.SUPPORT_SAS_TOKEN and \
+        #         connection.sas_subscription_key:
+        #     key = connection.sas_subscription_key
 
-        if key:
-            pc.set_subscription_key(key)
+        # if key:
+        #     pc.set_subscription_key(key)
 
         for item in items_list:
             # For APIs that support usage of SAS token we sign the whole item
             # so that the item assets can be accessed.
-            if self.api_capability == ApiCapability.SUPPORT_SAS_TOKEN:
-                item = pc.sign(item)
+            # if self.api_capability == ApiCapability.SUPPORT_SAS_TOKEN:
+            #     item = pc.sign(item)
             try:
                 properties_datetime = item.properties.get("datetime")
 

--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -206,8 +206,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
         self.sas_manager.token_refresh_error.connect(
             self.sas_token_refresh_error
         )
-
-        self.update_sas_frequency()
         self.populate_queryable_field()
 
         self.fetch_queryable_btn.clicked.connect(self.fetch_queryable)
@@ -286,8 +284,6 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
             Settings.REFRESH_FREQUENCY_UNIT,
             refresh_unit
         )
-
-        self.update_sas_frequency()
 
     def update_sas_frequency(self):
         # Set default refresh period to 8 hours
@@ -447,7 +443,7 @@ class QgisStacWidget(QtWidgets.QWidget, WidgetUi):
                            " {}, {}".
                            format(collection, err))
                         )
-            else:
+            if not self.get_selected_collections():
                 self.show_message(
                     tr("No collection has been selected"),
                     level=Qgis.Info

--- a/src/qgis_stac/ui/qgis_stac_widget.ui
+++ b/src/qgis_stac/ui/qgis_stac_widget.ui
@@ -434,7 +434,7 @@
           <bool>false</bool>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_8">
           <item>
@@ -513,8 +513,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>652</width>
-               <height>21</height>
+               <width>658</width>
+               <height>44</height>
               </rect>
              </property>
             </widget>
@@ -721,19 +721,6 @@
           </spacer>
          </item>
         </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item>
         <spacer name="verticalSpacer">


### PR DESCRIPTION
These updates removes search results items signing and now the SAS token signing will only be applied to the items assets when loading or downloading the respective assets.

Also this PR disable auto-signing of items as from now on all items assets will be getting new token each time their are being loaded or downloaded.