### PR TITLE
Fix for NETCDF assets loading

### DIFF
--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -170,6 +170,8 @@ class ResourceAsset:
     description: str
     type: str
     roles: typing.List[str]
+    name: str = None
+    downloaded: bool = False
 
 
 @dataclasses.dataclass

--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -65,16 +65,18 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
 
         self.load_box.setEnabled(self.asset.type in ''.join(layer_types))
         self.load_box.toggled.connect(self.asset_load_selected)
+        self.load_box.stateChanged.connect(self.asset_load_selected)
         self.download_box.toggled.connect(self.asset_download_selected)
+        self.download_box.stateChanged.connect(self.asset_download_selected)
 
         if self.asset.type not in layer_types:
             self.load_box.setToolTip(
-                tr("Asset contains a {} media type which "
+                tr("Asset contains {} media type which "
                    "cannot be loaded as a map layer in QGIS"
                    ).format(self.asset.type)
             )
 
-    def asset_load_selected(self):
+    def asset_load_selected(self, state=None):
         """ Emits the needed signal when an asset has been selected
         for loading.
         """
@@ -83,7 +85,7 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
         else:
             self.load_deselected.emit()
 
-    def asset_download_selected(self):
+    def asset_download_selected(self, state=None):
         """ Emits the needed signal when an asset has been selected
             for downloading.
             """

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -196,13 +196,8 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         :type asset: ResourceAsset
         """
 
-        log(f"popping our {asset.title}")
-        log(f"current add assets {self.load_assets}")
-
         self.load_assets.pop(asset.title) \
             if self.load_assets.get(asset.title, None) else None
-
-        log(f"POPPED -  {len(self.load_assets.items()) > 0}")
 
         self.load_btn.setText(
             f"Add selected assets as layers "

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -4,6 +4,8 @@
 """
 
 import os
+import os.path
+import gdal
 
 from pathlib import Path
 from osgeo import ogr
@@ -169,7 +171,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         """
         self.load_assets[asset.title] = asset
         self.load_btn.setText(
-            f"Add assets as layers ({len(self.load_assets.items())})"
+            f"Add selected assets as layers ({len(self.load_assets.items())})"
         )
 
         self.load_btn.setEnabled(True)
@@ -194,15 +196,20 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         :type asset: ResourceAsset
         """
 
+        log(f"popping our {asset.title}")
+        log(f"current add assets {self.load_assets}")
+
         self.load_assets.pop(asset.title) \
             if self.load_assets.get(asset.title, None) else None
+
+        log(f"POPPED -  {len(self.load_assets.items()) > 0}")
 
         self.load_btn.setText(
             f"Add selected assets as layers "
             f"({len(self.load_assets.items())})"
-        ) if self.load_assets else \
+        ) if len(self.load_assets.items()) > 0 else \
             self.load_btn.setText(
-                "Add selected assets as layers"
+                "Add assets as layers"
             )
 
         self.load_btn.setEnabled(len(self.load_assets.items()) > 0)
@@ -220,7 +227,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         self.download_btn.setText(
             f"Download the selected assets "
             f"({len(self.download_assets.items())})"
-        ) if self.download_assets else \
+        ) if len(self.download_assets.items()) > 0 else \
             self.download_btn.setText(
                 "Download the selected assets"
             )
@@ -322,7 +329,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             return
 
         url = self.sign_asset_href(asset.href)
-        extension = Path(url).suffix
+        extension = Path(asset.href).suffix
         extension_suffix = extension.split('?')[0] if extension else ""
         title = f"{asset.title}{extension_suffix}"
 
@@ -363,9 +370,9 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
 
             # After asset download has finished, load the asset
             # if it can be loaded as a QGIS map layer.
-            if load_asset and asset.type in layer_types:
+            if load_asset and asset.type in ''.join(layer_types):
                 asset.href = self.download_result["file"]
-                asset.title = title
+                asset.name = title
                 asset.type = AssetLayerType.GEOTIFF.value \
                     if AssetLayerType.COG.value in asset.type else asset.type
                 load_file = partial(self.load_file_asset, asset)
@@ -421,6 +428,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         :type value: int
         """
         if value == 100:
+            asset.downloaded = True
             self.load_asset(asset)
 
     def download_progress(self, value):
@@ -476,6 +484,8 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         point_cloud_types = ','.join([
             AssetLayerType.COPC.value,
         ])
+        current_asset_href = asset.href
+        asset.href = self.sign_asset_href(asset.href)
 
         if asset_type in raster_types:
             layer_type = QgsMapLayer.RasterLayer
@@ -485,19 +495,65 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             layer_type = QgsMapLayer.PointCloudLayer
 
         if asset_type in ''.join(
-                [AssetLayerType.COG.value,
-                 AssetLayerType.NETCDF.value]
+                [AssetLayerType.COG.value]
         ) and \
                 asset_type != AssetLayerType.GEOTIFF.value:
             asset_href = f"{self.vis_url_string}" \
                          f"{asset.href}"
+        elif asset_type in ''.join([
+            AssetLayerType.NETCDF.value]):
+            # For NETCDF assets type we need to download the intended asset first,
+            # then we read from the downloaded file and use all the available NETCDF
+            # variables on the file to load the layer.
+
+            asset.downloaded = os.path.exists(asset.href)
+            if asset.downloaded:
+                try:
+                    gdal.UseExceptions()
+                    open_file = gdal.Open(asset.href)
+                    asset_href = asset.href
+                    if open_file is not None:
+                        file_metadata = open_file.GetMetadata("SUBDATASETS")
+                        file_uris = []
+                        for key, value in file_metadata.items():
+                            if 'NAME' in key:
+                                file_uris.append(value)
+
+                        asset_href = file_uris
+                except RuntimeError as err:
+                    asset_href = asset.href
+                    log(
+                        tr("Runtime error when adding a NETCDF asset, {}").format(str(err))
+                    )
+            else:
+                asset.href = current_asset_href
+                self.download_asset(asset, True)
+                return
         else:
             asset_href = f"{asset.href}"
-
-        asset_href = self.sign_asset_href(asset_href)
-        asset_name = asset.title
-
+        asset_name = asset.name or asset.title
         self.update_inputs(False)
+
+        # Assets that will require more than one URI to be loaded,
+        # will register the respective URIs in a list.
+        if isinstance(asset_href, list):
+            for asset_uri in asset_href:
+                self.add_layer_task(asset_uri, asset_name, layer_type)
+        else:
+            self.add_layer_task(asset_href, asset_name, layer_type)
+
+    def add_layer_task(self, asset_href, asset_name, layer_type):
+        """ Helps in spinning up task for loading the required asset
+
+        :param asset_href: URI of the asset
+        :type asset_href: str
+
+        :param asset_name: Name of the asset
+        :type asset_name: str
+
+        :param layer_type: Layer type of the asset
+        :type layer_type: str
+        """
 
         layer_loader = LayerLoader(
             asset_href,
@@ -533,6 +589,13 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             For the layer to be added successfully, the task for loading
             layer need to exist and the corresponding layer need to be
             available.
+
+        :param asset_name: Name of the asset
+        :type asset_name: str
+
+        :param layer_loader: Plugin QGIS task responsible for loading assets
+        as layers.
+        :type layer_loader: LayerLoader
         """
         if layer_loader and layer_loader.layer:
             layer = layer_loader.layer
@@ -589,7 +652,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
 
 
 class LayerLoader(QgsTask):
-    """ Prepares and loads items as assets inside QGIS as layers."""
+    """ Prepares and loads items assets inside QGIS as layers."""
 
     def __init__(
             self,

--- a/src/qgis_stac/utils.py
+++ b/src/qgis_stac/utils.py
@@ -2,11 +2,13 @@
 """
     Plugin utilities
 """
-import os
-import sys
-import subprocess
-import uuid
+
 import datetime
+import gdal
+import os
+import subprocess
+import sys
+import uuid
 
 from qgis.PyQt import QtCore, QtGui
 from qgis.core import Qgis, QgsMessageLog
@@ -136,3 +138,16 @@ def open_documentation():
     QtGui.QDesktopServices.openUrl(
         QtCore.QUrl(SITE)
     )
+
+
+def check_gdal_version():
+    """ Checks if the installed gdal version matches the
+    required version by the plugin
+    """
+    gdal_version = gdal.VersionInfo("RELEASE_NAME")
+    if int(gdal.VersionInfo("VERSION_NUM")) < 1000000:
+        msg = tr(
+            "Make sure you are using GDAL >= 1.10 "
+            "You seem to have gdal {} installed".format(gdal_version))
+        log(msg)
+


### PR DESCRIPTION
This PR contains changes that provide a fix for a current bug in loading NETCDF assets layers. The changes contain a total overhaul of the approach in adding NETCDF assets as QGIS map layers.

The new approach is to first download the NETCDF asset and the use the GDAL package to read the available NETCDF variables and then add all the sublayers from the found variables.
The NETCDF asset type is the only type that will require to be downloaded first in order to be loaded as a layer, this is because before adding the NETCDF type we need prior details about the available variables which can only be fetch if the asset has already been downloaded.

The changes also update workflow in checking if the plugin has finished downloading the assets, instead of checking the progress value of the download, the plugin will now be checking if the processing algorithm has returned last results. A new function `sign_asset_href` is also included to help signing assets url for the SAS based connection items.

Screenshot of loading NETCDF assets using the `GOES-R Cloud & Moisture Imagery` collection from Microsoft planetary computer STAC catalog.
![netcdf_loading](https://user-images.githubusercontent.com/2663775/174637859-64f1b072-248b-4ed2-baa7-f869aca4d07b.gif)


