### PR TITLE
Update signal connection to assets loading settings

### DIFF
--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -226,6 +226,7 @@ class QgisStacWidget(QtWidgets.QMainWindow, WidgetUi):
         self.asset_loading.setChecked(auto_asset_loading)
 
         self.asset_loading.toggled.connect(self.update_plugin_settings)
+        self.asset_loading.stateChanged.connect(self.update_plugin_settings)
 
         refresh_time_value = settings_manager.get_value(
             Settings.REFRESH_FREQUENCY,


### PR DESCRIPTION
Now checking for both `toggled` and `stateChanged` Qt checkbox signal when user change the assets loading when downloading setting.