### PR TITLE
Clear selected footrpints when new search has finished

### DIFF
--- a/src/qgis_stac/gui/qgis_stac_widget.py
+++ b/src/qgis_stac/gui/qgis_stac_widget.py
@@ -761,8 +761,9 @@ class QgisStacWidget(QtWidgets.QMainWindow, WidgetUi):
                 self.next_btn.setEnabled(len(results) > 0)
                 self.prev_btn.setEnabled(self.page > 1)
                 self.footprint_btn.setEnabled(
-                    len(self.footprint_items.items()) > 0
+                    False
                 )
+                self.footprint_items = {}
             self.container.setCurrentIndex(1)
 
         else:


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/200

When new search has finished we need to clear the past selected footprints.