### PR TITLE
Fix for error when testing a new connection

### DIFF
--- a/src/qgis_stac/gui/connection_dialog.py
+++ b/src/qgis_stac/gui/connection_dialog.py
@@ -249,6 +249,9 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
 
         connection_id = uuid.uuid4()
         capability = None
+        search_items = []
+
+        sas_subscription_key = self.sas_subscription_key.text()
 
         if self.capabilities.currentText() != "":
             capability = ApiCapability(self.capabilities.currentText())
@@ -263,6 +266,8 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
             conformances=self.conformance,
             created_date=datetime.datetime.now(),
             auth_config=self.auth_config.configId(),
+            search_items=search_items,
+            sas_subscription_key=sas_subscription_key,
         )
 
         return connection_settings


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/210

Adds the missing variable when creating a connection from the connection dialog inputs.