### PR TITLE
Remove plugin web menu entry when plugin is uninstalled

### DIFF
--- a/src/qgis_stac/main.py
+++ b/src/qgis_stac/main.py
@@ -179,6 +179,7 @@ class QgisStac:
         """Removes the plugin menu item and icon from QGIS GUI."""
         for action in self.actions:
             self.iface.removePluginMenu(self.tr(u"&STAC API Browser Plugin"), action)
+            self.iface.removePluginWebMenu(self.tr(u"&STAC API Browser Plugin"), action)
             self.iface.removeToolBarIcon(action)
 
     def run(self):


### PR DESCRIPTION
Fixes https://github.com/stac-utils/qgis-stac-plugin/issues/209

Deletes the plugin menu entry on the plugin web menu.
