### PR TITLE
pass auth_config through to ContentFetcherTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,22 @@ official plugin repository.
 To use the plugin for development purposes, clone the repository locally,
 install poetry, a python dependencies management tool see https://python-poetry.org/docs/#installation
 then using the poetry tool, update the poetry lock file and install plugin dependencies by running 
-``` 
+```sh
 poetry update --lock
 poetry install --no-dev
 ```
 
 To install the plugin into the QGIS application use the below command
-```
+```sh
 poetry run python admin.py install
 ```
+
+#### Testing
+To run the unit tests, run the `run-tests.sh` script. This will spin up the QGIS
+docker container for several versions of QGIS and execute the unit tests.
+```sh
+./run-tests.sh
+```
+
 
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,28 +1,29 @@
 #!/usr/bin/env bash
 
-QGIS_IMAGE=qgis/qgis
+# list of QGIS versions to test
+QGIS_VERSION_TAGS=( \
+  release-3_16 \
+  release-3_20 \
+  release-3_22 \
+  release-3_24 \
+  final-3_26_0 \
+  final-3_28_0 \
+)
 
-QGIS_IMAGE_V_3_16=release-3_16
-QGIS_IMAGE_V_3_20=release-3_20
+# base QGIS docker image
+export IMAGE=qgis/qgis
 
-QGIS_VERSION_TAGS=($QGIS_IMAGE_V_3_16 $QGIS_IMAGE_V_3_20)
+# docker-compose environment variables
+export WITH_PYTHON_PEP=false
+export ON_TRAVIS=false
+export MUTE_LOGS=true
 
-export IMAGE=$QGIS_IMAGE
-
-for TAG in "${QGIS_VERSION_TAGS[@]}"
-do
-    echo "Running tests for QGIS $TAG"
-    export QGIS_VERSION_TAG=$TAG
-    export WITH_PYTHON_PEP=false
-    export ON_TRAVIS=false
-    export MUTE_LOGS=true
-
+for QGIS_VERSION_TAG in "${QGIS_VERSION_TAGS[@]}"; do
+    echo "Running tests for QGIS ${QGIS_VERSION_TAG}"
+    docker pull ${IMAGE}:${QGIS_VERSION_TAG}
     docker-compose up -d
-
     sleep 10
     docker-compose exec -T qgis-testing-environment sh -c "pip3 install flask"
-
     docker-compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package
     docker-compose down
-
 done

--- a/src/qgis_stac/api/base.py
+++ b/src/qgis_stac/api/base.py
@@ -119,6 +119,7 @@ class BaseClient(QtCore.QObject):
             api_capability=self.capability,
             response_handler=self.handle_items,
             error_handler=self.handle_error,
+            auth_config=self.auth_config,
         )
 
         QgsApplication.taskManager().addTask(self.content_task)
@@ -135,6 +136,7 @@ class BaseClient(QtCore.QObject):
             resource_type=ResourceType.COLLECTION,
             response_handler=self.handle_collections,
             error_handler=self.handle_error,
+            auth_config=self.auth_config,
         )
 
         QgsApplication.taskManager().addTask(self.content_task)
@@ -156,6 +158,7 @@ class BaseClient(QtCore.QObject):
             resource_type=ResourceType.COLLECTION,
             response_handler=self.handle_collection,
             error_handler=self.handle_error,
+            auth_config=self.auth_config,
         )
 
         QgsApplication.taskManager().addTask(self.content_task)
@@ -172,6 +175,7 @@ class BaseClient(QtCore.QObject):
             resource_type=ResourceType.CONFORMANCE,
             response_handler=self.handle_conformance,
             error_handler=self.handle_error,
+            auth_config=self.auth_config,
         )
 
         QgsApplication.taskManager().addTask(self.content_task)


### PR DESCRIPTION
This makes it possible to pass API headers from a `QgsAuthMethodConfig` to `pystac_client.Client.open`. To do this right we would definitely want a more thorough treatment of alternative authentication options but I just want to put it out here for others to look at.

This resolves #206 and starts us on the path towards #207 . 