### PR TITLE
Handle STACTypeError from pystac

### DIFF
--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -47,6 +47,8 @@ from ..lib import planetary_computer as pc
 from pystac_client import Client
 from pystac_client.exceptions import APIError
 
+from pystac.errors import STACTypeError
+
 from ..utils import log, tr
 
 from ..conf import settings_manager
@@ -136,7 +138,12 @@ class ContentFetcherTask(QgsTask):
                 self.pagination = ResourcePagination()
             else:
                 raise NotImplementedError
-        except (APIError, NotImplementedError, JSONDecodeError) as err:
+        except (
+                APIError,
+                NotImplementedError,
+                JSONDecodeError,
+                STACTypeError
+        ) as err:
             log(str(err))
             self.error = str(err)
 


### PR DESCRIPTION
When fetching collections from API we need to relay feedback to user after getting exceptions based on [pystac errors](https://pystac.readthedocs.io/en/stable/api/errors.html).