### PR TITLE
Fix collection information dialog 

### DIFF
--- a/src/qgis_stac/api/network.py
+++ b/src/qgis_stac/api/network.py
@@ -190,7 +190,7 @@ class ContentFetcherTask(QgsTask):
             links.append(resource_link)
 
         providers = []
-        for provider in collection_response.providers:
+        for provider in collection_response.providers or []:
             resource_provider = ResourceProvider(
                 name=provider.name,
                 description=provider.description,


### PR DESCRIPTION
Fix for #234

This PR contains a change that fixes collection information dialog error that was happening when the collection information dialog for a collection that doesn't contain providers details is opened.

It has been mentioned in https://github.com/radiantearth/stac-api-spec/blob/master/stac-spec/collection-spec/collection-spec.md#collection-fields, `providers` field is not a required field and the STAC collection may not contain them.

Before fix
![image](https://user-images.githubusercontent.com/2663775/230336433-c88b42f1-45d6-4e33-ac5b-ee20a99768e1.png)

After fix
![image](https://user-images.githubusercontent.com/2663775/230336369-89038f71-5be3-44a5-9f3e-c6af097bfadb.png)
