### PR TITLE
Resolve asset type error

### DIFF
--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -53,14 +53,15 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
 
         self.title_la.setText(self.asset.title)
         self.type_la.setText(self.asset.type)
+        asset_load = self.asset_loadable()
 
-        self.load_box.setEnabled(self.asset_loadable())
+        self.load_box.setEnabled(asset_load)
         self.load_box.toggled.connect(self.asset_load_selected)
         self.load_box.stateChanged.connect(self.asset_load_selected)
         self.download_box.toggled.connect(self.asset_download_selected)
         self.download_box.stateChanged.connect(self.asset_download_selected)
 
-        if self.asset_loadable():
+        if asset_load:
             self.load_box.setToolTip(
                 tr("Asset contains {} media type which "
                    "cannot be loaded as a map layer in QGIS"


### PR DESCRIPTION
Fix for https://github.com/stac-utils/qgis-stac-plugin/issues/227

These changes add functionality to check for the asset type from the provided asset href when the corresponding STAC item asset doesn't contain media type.