### PR TITLE
Fix pagination performance

### DIFF
--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -319,7 +319,7 @@ class Item:
 class ItemSearch:
     """ Definition for the pystac-client item search parameters"""
     ids: typing.Optional[list] = None
-    page: typing.Optional[int] = 1
+    page: typing.Optional[int] = None
     page_size: typing.Optional[int] = 10
     collections: typing.Optional[list] = None
     datetime: typing.Optional[QtCore.QDateTime] = None

--- a/src/qgis_stac/lib/pystac_client/item_search.py
+++ b/src/qgis_stac/lib/pystac_client/item_search.py
@@ -435,6 +435,20 @@ class ItemSearch:
         for page in self._stac_io.get_pages(self.url, self.method, self.get_parameters()):
             yield ItemCollection.from_dict(page, preserve_dict=False, root=self.client)
 
+    def page(self, page=None, token=None) -> Dict:
+        if isinstance(self._stac_io, StacApiIO):
+            page = self._stac_io.get_page(
+                self.url,
+                self.method,
+                self.get_parameters(),
+                page=page,
+                token=token,
+            )
+            page_collection = ItemCollection.from_dict(
+                page, preserve_dict=False, root=self.client
+            ) if page is not None else None
+            return page_collection
+
     def get_items(self) -> Iterator[Item]:
         """Iterator that yields :class:`pystac.Item` instances for each item matching the given search parameters. Calls
         :meth:`ItemSearch.item_collections()` internally and yields from

--- a/src/qgis_stac/lib/pystac_client/stac_api_io.py
+++ b/src/qgis_stac/lib/pystac_client/stac_api_io.py
@@ -219,6 +219,47 @@ class StacApiIO(DefaultStacIO):
             next_link = next((link for link in page.get('links', []) if link['rel'] == 'next'),
                              None)
 
+    def get_page(
+            self,
+            url: str,
+            method: Optional[str] = None,
+            parameters: Optional[Dict[str, Any]] = None,
+            page: Optional = None,
+            token: Optional = None
+    ):
+        """Get page using the passed page number or the token
+
+        Return:
+            Dict[str, Any] : JSON content from a single page
+        """
+        if page is None and token is None:
+            # Always return the first page if page is not passed
+            parameters['page'] = 1
+            page = self.read_json(
+                url,
+                method=method,
+                parameters=parameters
+            )
+        if page is not None:
+            parameters['page'] = page
+            page = self.read_json(
+                url,
+                method=method,
+                parameters=parameters
+            )
+        elif token is not None:
+            parameters['token'] = token
+            page = self.read_json(
+                url,
+                method=method,
+                parameters=parameters
+            )
+        else:
+            page = None
+        return page
+
+        return page
+
     def assert_conforms_to(self, conformance_class: ConformanceClasses) -> None:
         """Raises a :exc:`NotImplementedError` if the API does not publish the given conformance class. This method
         only checks against the ``"conformsTo"`` property from the API landing page and does not make any additional


### PR DESCRIPTION
The current pagination functionality scales with a large order when fetching next pages. This PR updates the `pystac_client` library with a function that helps getting specific STAC search and collections pages and use the function inside the plugin for the pagination functionality.

See https://github.com/radiantearth/stac-api-spec/tree/master/item-search#pagination
