### PR TITLE
Allow repo to be installed with pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "1.1.0"
 description = "QGIS plugin for reading STAC API catalogs"
 authors = ["Kartoza <info@kartoza.com>"]
 license = "GPL v3.0"
+packages = [
+    { include = "qgis_stac", from="src" },
+]
 
 [tool.poetry.dependencies]
 mkdocs = "^1.2.3"


### PR DESCRIPTION
This tells poetry's masonry build backend to look for the package under `src/` (based on [the poetry
docs](https://python-poetry.org/docs/pyproject/#packages) . Without this, trying to install
this package with just pip from the repo fails with:

```
$ pip install .
Processing /Users/yuvipanda/code/jupyter-remote-desktop-proxy/images/qgis/qgis-stac-plugin
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      Traceback (most recent call last):
        File "/Users/yuvipanda/.local/share/virtualenvs/qgis-stac-plugin/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/yuvipanda/.local/share/virtualenvs/qgis-stac-plugin/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/Users/yuvipanda/.local/share/virtualenvs/qgis-stac-plugin/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/private/var/folders/p4/gnx7h_mj73v92nj_v93475v80000gn/T/pip-build-env-jhnlomhc/overlay/lib/python3.10/site-packages/poetry/core/masonry/api.py", line 42, in prepare_metadata_for_build_wheel
          builder = WheelBuilder(poetry)
        File "/private/var/folders/p4/gnx7h_mj73v92nj_v93475v80000gn/T/pip-build-env-jhnlomhc/overlay/lib/python3.10/site-packages/poetry/core/masonry/builders/wheel.py", line 61, in __init__
          super().__init__(poetry, executable=executable)
        File "/private/var/folders/p4/gnx7h_mj73v92nj_v93475v80000gn/T/pip-build-env-jhnlomhc/overlay/lib/python3.10/site-packages/poetry/core/masonry/builders/builder.py", line 85, in __init__
          self._module = Module(
        File "/private/var/folders/p4/gnx7h_mj73v92nj_v93475v80000gn/T/pip-build-env-jhnlomhc/overlay/lib/python3.10/site-packages/poetry/core/masonry/utils/module.py", line 69, in __init__          raise ModuleOrPackageNotFound(
      poetry.core.masonry.utils.module.ModuleOrPackageNotFound: No file/folder found for package qgis-stac-plugin
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```