### PR TITLE
Fix item assets dialog title

### DIFF
--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -105,7 +105,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         if len(self.assets) > 0:
             self.title.setText(
                 tr("Item {}").
-                format(self.item.id, len(self.assets))
+                format(self.item.id)
             )
             self.asset_count.setText(
                 tr("{} available asset(s)").
@@ -115,7 +115,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         else:
             self.title.setText(
                 tr("Item {} has no assets").
-                format(len(self.item.id))
+                format(self.item.id)
             )
 
         scroll_container = QtWidgets.QWidget()


### PR DESCRIPTION
Updates the assets dialog title instead of displaying the length of the item id to show the exact item id when the item assets are empty.