### PR TITLE
Updates on the CI workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,9 +3,9 @@ on: workflow_dispatch
 
 jobs:
   build-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: qgis/qgis:release-3_16
+      image: qgis/qgis:release-3_34
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Running tests on QGIS ${{ matrix.qgis_version_tag }}
 
     strategy:
@@ -29,10 +29,9 @@ jobs:
       matrix:
         qgis_version_tag:
           - release-3_16
-          - release-3_20
           - release-3_22
-          - release-3_24
-          - final-3_26_0
+          - release-3_34
+          - release-3_36
 
     steps:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: qgis/qgis:release-3_20
+      image: qgis/qgis:release-3_34
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Adds recent QGIS versions to run the plugin CI tests against. Currrent QGIS LTR version is on 3.34, for more info https://www.qgis.org/en/site/getinvolved/development/roadmap.html#release