### PR TITLE
Update Earth Search API version to v1 from v0

### DIFF
--- a/src/qgis_stac/definitions/catalog.py
+++ b/src/qgis_stac/definitions/catalog.py
@@ -16,7 +16,7 @@ CATALOGS = [
     {
         "id": "d74817bf-da1f-44d7-a464-b87d4009c8a3",
         "name": "Earth Search",
-        "url": "https://earth-search.aws.element84.com/v0",
+        "url": "https://earth-search.aws.element84.com/v1",
         "selected": False,
         "capability": None,
     },


### PR DESCRIPTION
The Element84 search endpoint v0 is not longer maintained. This PR changes the version to v1.
https://earth-search.aws.element84.com/v1