### PR TITLE
add a default 3D renderer in PointCloud loader

### DIFF
--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -29,8 +29,9 @@ from qgis.core import (
     QgsRasterLayer,
     QgsTask,
     QgsVectorLayer,
-
 )
+from qgis._3d import QgsPointCloudLayer3DRenderer
+
 from ..lib import planetary_computer as pc
 
 from ..resources import *
@@ -727,6 +728,11 @@ class LayerLoader(QgsTask):
             # hence we clone the layer before storing it, so it can
             # be used in the main thread.
             self.layer = self.layer.clone()
+            if self.layer_type == QgsMapLayer.PointCloudLayer:
+                # add 3D renderer with sync to 2D as default
+                r = QgsPointCloudLayer3DRenderer()
+                self.layer.setRenderer3D(r)
+                self.layer.setSync3DRendererTo2DRenderer(True)
         else:
             provider_error = tr("error {}").format(
                 self.layer.dataProvider().error()


### PR DESCRIPTION
When adding a point cloud layer with the QGIS GUI, it also adds to a 3D renderer to the layer with "Follow 2D Symbology" as the default behavior in 3D View.

At the moment, qgis-stac-plugin does not define a 3D renderer for the added point cloud layer. As such, requires the user to discover and change the 3D view property of each point cloud layer from "No renderer" to "Follow 2D Symbology" in order to be able to view the point clouds in the 3D map view.

This PR aims at adding a default 3D renderer in order to mimic the point cloud layer addition of the GUI, and be able to view by default the point cloud in the 3D map view.

