### PR TITLE
GeoZarr / Zarr v3 reflectance support (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ## [Unreleased] 
 
+- Experimental: add GeoZarr (Zarr v3) reflectance loading with a fast XYZ preview layer and a GDAL VRT-backed “data” layer.
+
 ### 1.0.0-pre 2022-01-11
 - Changed loading and downloading assets workflow [#93](https://github.com/stac-utils/qgis-stac-plugin/pull/93).
 - Implemented testing connection functionality.

--- a/docs/geozarr/geozarr-zarrv3-reflectance-support.md
+++ b/docs/geozarr/geozarr-zarrv3-reflectance-support.md
@@ -1,0 +1,50 @@
+# GeoZarr (Zarr v3) reflectance support
+
+## Tested environment
+
+- QGIS: 3.44.6-Solothurn
+- GDAL: 3.13.0dev-e878b5b406-dirty (released 2026/01/03)
+
+Zarr v3 sharding and HTTP range behavior can vary by GDAL version; this feature is implemented conservatively to reduce unnecessary reads and make failures less disruptive.
+
+## Goal
+
+Add experimental support for Zarr v3/GeoZarr reflectance assets so the plugin can:
+
+- add a fast preview layer (tiles) for immediate visualization,
+- add a “data” layer backed by a GDAL VRT for value inspection,
+- keep preview and data aligned spatially,
+- avoid expensive auto-stats and unnecessary network reads.
+
+## UX
+
+- If an item exposes an XYZ tiles link and a reflectance Zarr asset, the plugin adds:
+  - `Surface Reflectance (preview)` (XYZ tiles)
+  - `Surface Reflectance (data)` (GeoZarr VRT), added hidden by default
+
+## Implementation highlights
+
+### GeoZarr VRT
+
+- Builds a single-resolution VRT with separate bands.
+- Tries common reflectance resolutions (r10m/r20m/r60m) when auto-selecting.
+
+### Georeferencing
+
+- Injects `SRS` and `GeoTransform` into the VRT.
+- Supports STAC `proj:transform` with 6 values (GDAL GeoTransform).
+
+### Performance notes
+
+- Avoids eager pixel reads during background creation (which can trigger expensive shard fetches).
+
+### Visualization defaults
+
+- Uses true-color mapping for reflectance: `b04/b03/b02`.
+- Applies explicit per-channel stretch ranges to avoid NaN min/max from auto-stats:
+  - float reflectance: 0..1
+  - scaled integer reflectance: 0..10000
+
+## Credentials
+
+No secrets are embedded. If authentication becomes necessary for a STAC endpoint, prefer QGIS Auth Manager; only fall back to documented environment variables.

--- a/src/qgis_stac/__init__.py
+++ b/src/qgis_stac/__init__.py
@@ -25,10 +25,10 @@
 import os
 import sys
 
-LIB_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), 'lib'))
-if LIB_DIR not in sys.path:
-    sys.path.append(LIB_DIR)
+LIB_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "lib"))
+if LIB_DIR in sys.path:
+    sys.path.remove(LIB_DIR)
+sys.path.insert(0, LIB_DIR)
 
 
 # noinspection PyPep8Naming

--- a/src/qgis_stac/api/models.py
+++ b/src/qgis_stac/api/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-""" QGIS STAC API plugin models
+"""QGIS STAC API plugin models
 
 The STAC API related resources have been defined
 in accordance to their definition available on
@@ -15,9 +15,7 @@ import typing
 
 from uuid import UUID, uuid4
 
-from qgis.PyQt import (
-    QtCore
-)
+from qgis.PyQt import QtCore
 
 from qgis.core import QgsRectangle
 
@@ -27,6 +25,7 @@ from ..lib.pystac.item import Item as STACObject
 @dataclasses.dataclass
 class ResourcePagination:
     """The plugin resource pagination for the search results"""
+
     total_items: int = 0
     total_pages: int = 0
     current_page: int = 1
@@ -40,92 +39,103 @@ class ApiCapability(enum.Enum):
 
 
 class AssetRoles(enum.Enum):
-    """ STAC Item assets roles defined as outlined in
+    """STAC Item assets roles defined as outlined in
     https://github.com/radiantearth/stac-api-spec/blob/
     master/stac-spec/item-spec/item-spec.md#asset-roles
     """
-    THUMBNAIL = 'thumbnail'
-    OVERVIEW = 'overview'
-    DATA = 'data'
-    METADATA = 'metadata'
+
+    THUMBNAIL = "thumbnail"
+    OVERVIEW = "overview"
+    DATA = "data"
+    METADATA = "metadata"
 
 
 class AssetLayerType(enum.Enum):
-    """ Types of assets layers that can be added to QGIS, values are defined as in
+    """Types of assets layers that can be added to QGIS, values are defined as in
     https://github.com/radiantearth/stac-api-spec/blob/
     master/stac-spec/best-practices.md#common-media-types-in-stac"""
-    COG = 'image/tiff; application=geotiff; profile=cloud-optimized'
-    COPC = 'application/vnd.laszip+copc'
-    GEOTIFF = 'image/tiff; application=geotiff'
-    GEOJSON = 'application/geo+json'
-    GEOPACKAGE = 'application/geopackage+sqlite3'
-    VECTOR = 'ogr'
-    NETCDF = 'application/netcdf; application/x-netcdf'
+
+    COG = "image/tiff; application=geotiff; profile=cloud-optimized"
+    COPC = "application/vnd.laszip+copc"
+    GEOTIFF = "image/tiff; application=geotiff"
+    GEOJSON = "application/geo+json"
+    GEOPACKAGE = "application/geopackage+sqlite3"
+    VECTOR = "ogr"
+    NETCDF = "application/netcdf; application/x-netcdf"
+    ZARR = "application/vnd+zarr"
 
 
 class Constants(enum.Enum):
-    """ Default plugin constants"""
+    """Default plugin constants"""
+
     PAGE_SIZE = 10
 
 
 class FilterLang(enum.Enum):
-    """ Filter languages that can be used to filter items during
+    """Filter languages that can be used to filter items during
     STAC API item search
     """
-    CQL_TEXT = 'CQL_TEXT'
-    CQL2_TEXT = 'CQL2_TEXT'
-    CQL_JSON = 'CQL_JSON'
-    CQL2_JSON = 'CQL2_JSON'
-    STAC_QUERY = 'STAC_QUERY'
+
+    CQL_TEXT = "CQL_TEXT"
+    CQL2_TEXT = "CQL2_TEXT"
+    CQL_JSON = "CQL_JSON"
+    CQL2_JSON = "CQL2_JSON"
+    STAC_QUERY = "STAC_QUERY"
 
 
 class FilterOperator(enum.Enum):
-    """ Filter text operators.
-    """
-    LESS_THAN = '<'
-    GREATER_THAN = '>'
-    LESS_THAN_EQUAL = '<='
-    GREATER_THAN_EQUAL = '>='
-    EQUAL = '='
+    """Filter text operators."""
+
+    LESS_THAN = "<"
+    GREATER_THAN = ">"
+    LESS_THAN_EQUAL = "<="
+    GREATER_THAN_EQUAL = ">="
+    EQUAL = "="
 
 
 class QueryablePropertyType(enum.Enum):
-    """ Represents STAC queryable property types."""
-    INTEGER = 'integer'
-    STRING = 'string'
-    OBJECT = 'object'
-    ENUM = 'enum'
-    DATETIME = 'datetime'
+    """Represents STAC queryable property types."""
+
+    INTEGER = "integer"
+    STRING = "string"
+    OBJECT = "object"
+    ENUM = "enum"
+    DATETIME = "datetime"
+
 
 class SortField(enum.Enum):
-    """ Holds the field value used when sorting items results."""
-    ID = 'ID'
-    COLLECTION = 'COLLECTION'
-    DATE = 'DATE'
+    """Holds the field value used when sorting items results."""
+
+    ID = "ID"
+    COLLECTION = "COLLECTION"
+    DATE = "DATE"
 
 
 class SortOrder(enum.Enum):
-    """ Holds the ordering value when sorting items results."""
-    ASCENDING = 'ASCENDING'
-    DESCENDING = 'DESCENDING'
+    """Holds the ordering value when sorting items results."""
+
+    ASCENDING = "ASCENDING"
+    DESCENDING = "DESCENDING"
 
 
 class SortOrderPrefix(enum.Enum):
-    """ Holds the STAC ordering prefix value when sorting items results."""
-    ASCENDING = '+'
-    DESCENDING = '-'
+    """Holds the STAC ordering prefix value when sorting items results."""
+
+    ASCENDING = "+"
+    DESCENDING = "-"
 
 
 class TimeUnits(enum.Enum):
-    """ Represents time units."""
-    SECONDS = 'SECONDS'
-    MINUTES = 'MINUTES'
-    HOURS = 'HOURS'
-    DAYS = 'DAYS'
+    """Represents time units."""
+
+    SECONDS = "SECONDS"
+    MINUTES = "MINUTES"
+    HOURS = "HOURS"
+    DAYS = "DAYS"
 
 
 class GeometryType(enum.Enum):
-    """Enum to represent the available geometry types """
+    """Enum to represent the available geometry types"""
 
     POINT = "Point"
     LINESTRING = "LineString"
@@ -136,7 +146,8 @@ class GeometryType(enum.Enum):
 
 
 class ResourceType(enum.Enum):
-    """Represents the STAC API resource types """
+    """Represents the STAC API resource types"""
+
     COLLECTION = "Collection"
     FEATURE = "Feature"
     CATALOG = "Catalog"
@@ -144,12 +155,14 @@ class ResourceType(enum.Enum):
 
 
 class QgsAuthMethods(enum.Enum):
-    """ Represents the QGIS authentication method names."""
-    API_HEADER = 'APIHeader'
+    """Represents the QGIS authentication method names."""
+
+    API_HEADER = "APIHeader"
 
 
 class QueryableFetchType(enum.Enum):
     """Queryable fetch types"""
+
     CATALOG = "Catalog"
     COLLECTION = "Collection"
     COLLECTIONS = "Collections"
@@ -158,18 +171,21 @@ class QueryableFetchType(enum.Enum):
 @dataclasses.dataclass
 class SpatialExtent:
     """Spatial extent as defined by the STAC API"""
+
     bbox: typing.List[int]
 
 
 @dataclasses.dataclass
 class TemporalExtent:
     """Temporal extent as defined by the STAC API"""
+
     interval: typing.List[str]
 
 
 @dataclasses.dataclass
 class ResourceAsset:
     """The STAC API asset"""
+
     href: str
     title: str
     description: str
@@ -182,6 +198,7 @@ class ResourceAsset:
 @dataclasses.dataclass
 class ResourceExtent:
     """The STAC API extent"""
+
     spatial: SpatialExtent
     temporal: TemporalExtent
 
@@ -189,6 +206,7 @@ class ResourceExtent:
 @dataclasses.dataclass
 class ResourceLink:
     """The STAC API link resource"""
+
     href: str
     rel: str
     title: str
@@ -201,6 +219,7 @@ class ResourceProperties:
     which contains additional metadata fields
     for the STAC API resources.
     """
+
     title: str = None
     description: str = None
     resource_datetime: datetime.datetime = None
@@ -218,6 +237,7 @@ class ResourceProvider:
     which contains information about the provider that
     captured the content available on a STAC API collections.
     """
+
     name: str
     description: str
     roles: [str]
@@ -228,6 +248,7 @@ class ResourceProvider:
 # all geometry types
 class ResourceGeometry:
     """The GeoJSON geometry footprint STAC API assets"""
+
     type: GeometryType
     coordinates: typing.List[typing.List[int]]
 
@@ -238,6 +259,7 @@ class QueryableProperty:
     https://github.com/radiantearth/stac-api-spec/blob/master/
     fragments/filter/README.md#queryables
     """
+
     name: str
     title: str
     type: str
@@ -254,6 +276,7 @@ class Queryable:
     https://github.com/radiantearth/stac-api-spec/blob/master/
     fragments/filter/README.md#queryables
     """
+
     schema: str = None
     id: str = None
     type: str = None
@@ -264,7 +287,8 @@ class Queryable:
 
 @dataclasses.dataclass
 class Catalog:
-    """ Represents the STAC API Catalog"""
+    """Represents the STAC API Catalog"""
+
     id: int
     uuid: UUID
     title: str
@@ -277,7 +301,8 @@ class Catalog:
 
 @dataclasses.dataclass
 class Collection:
-    """ Represents the STAC API Collection"""
+    """Represents the STAC API Collection"""
+
     id: str = None
     uuid: UUID = None
     title: str = None
@@ -296,7 +321,7 @@ class Collection:
 
 @dataclasses.dataclass
 class Conformance:
-    """ Represents the stored plugin conformance class"""
+    """Represents the stored plugin conformance class"""
 
     id: UUID = None
     name: str = None
@@ -305,7 +330,8 @@ class Conformance:
 
 @dataclasses.dataclass
 class Item:
-    """ Represents the plugin STAC API Item"""
+    """Represents the plugin STAC API Item"""
+
     id: str = None
     item_uuid: UUID = uuid4()
     type: ResourceType = None
@@ -322,7 +348,8 @@ class Item:
 
 @dataclasses.dataclass
 class ItemSearch:
-    """ Definition for the pystac-client item search parameters"""
+    """Definition for the pystac-client item search parameters"""
+
     ids: typing.Optional[list] = None
     page: typing.Optional[int] = 1
     page_size: typing.Optional[int] = 10
@@ -337,22 +364,26 @@ class ItemSearch:
     sort_order: SortOrder = SortOrder.ASCENDING
 
     def params(self):
-        """ Converts the class members into a dictionary that
+        """Converts the class members into a dictionary that
         can be used in searching the STAC API items using the
         pystac-client library
 
         :returns: Dictionary of parameters
         :rtype: dict
         """
-        spatial_extent_available = (self.spatial_extent and
-                                    not self.spatial_extent.isNull()
-                                    )
-        bbox = [
-            self.spatial_extent.xMinimum(),
-            self.spatial_extent.yMinimum(),
-            self.spatial_extent.xMaximum(),
-            self.spatial_extent.yMaximum(),
-        ] if spatial_extent_available else None
+        spatial_extent_available = (
+            self.spatial_extent and not self.spatial_extent.isNull()
+        )
+        bbox = (
+            [
+                self.spatial_extent.xMinimum(),
+                self.spatial_extent.yMinimum(),
+                self.spatial_extent.xMaximum(),
+                self.spatial_extent.yMaximum(),
+            ]
+            if spatial_extent_available
+            else None
+        )
 
         datetime_str = None
         if self.start_datetime and not self.end_datetime:
@@ -360,54 +391,59 @@ class ItemSearch:
         elif self.end_datetime and not self.start_datetime:
             datetime_str = f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
         elif self.start_datetime and self.end_datetime:
-            datetime_str = f"{self.start_datetime.toString(QtCore.Qt.ISODate)}/" \
-                           f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
+            datetime_str = (
+                f"{self.start_datetime.toString(QtCore.Qt.ISODate)}/"
+                f"{self.end_datetime.toString(QtCore.Qt.ISODate)}"
+            )
 
-        method = 'POST'
+        method = "POST"
         text = None
 
         if self.filter_text:
             if self.filter_lang == FilterLang.CQL2_TEXT:
-                method = 'GET'
+                method = "GET"
                 text = self.filter_text
             else:
                 text = json.loads(self.filter_text)
 
         filter_lang_values = {
-            FilterLang.CQL_JSON: 'cql-json',
-            FilterLang.CQL2_JSON: 'cql2-json',
-            FilterLang.CQL2_TEXT: 'cql2-text'
+            FilterLang.CQL_JSON: "cql-json",
+            FilterLang.CQL2_JSON: "cql2-json",
+            FilterLang.CQL2_TEXT: "cql2-text",
         }
 
-        filter_lang_text = filter_lang_values[self.filter_lang] \
-            if self.filter_lang else None
+        filter_lang_text = (
+            filter_lang_values[self.filter_lang] if self.filter_lang else None
+        )
 
-        filter_text = text \
-            if self.filter_lang in \
-               [FilterLang.CQL_JSON,
-                FilterLang.CQL2_JSON,
-                FilterLang.CQL2_TEXT
-                ] else None
+        filter_text = (
+            text
+            if self.filter_lang
+            in [FilterLang.CQL_JSON, FilterLang.CQL2_JSON, FilterLang.CQL2_TEXT]
+            else None
+        )
 
-        query_text = text \
-            if self.filter_lang == FilterLang.STAC_QUERY else None
+        query_text = text if self.filter_lang == FilterLang.STAC_QUERY else None
 
         sort_lang_values = {
-            SortField.ID: 'id',
-            SortField.COLLECTION: 'collection',
+            SortField.ID: "id",
+            SortField.COLLECTION: "collection",
         }
 
         field = sort_lang_values[self.sortby] if self.sortby else None
 
-        order = 'asc' \
-            if self.sort_order == SortOrder.ASCENDING else 'desc'
+        order = "asc" if self.sort_order == SortOrder.ASCENDING else "desc"
 
-        sort_load = [
-            {
-                'field': field,
-                'direction': order,
-            }
-        ] if self.sortby else []
+        sort_load = (
+            [
+                {
+                    "field": field,
+                    "direction": order,
+                }
+            ]
+            if self.sortby
+            else []
+        )
 
         parameters = {
             "ids": self.ids,
@@ -429,7 +465,8 @@ class ItemSearch:
 
 @dataclasses.dataclass
 class SearchFilters:
-    """ Stores search filters inputs"""
+    """Stores search filters inputs"""
+
     page: typing.Optional[int] = 1
     page_size: typing.Optional[int] = 10
     collections: typing.Optional[list] = None

--- a/src/qgis_stac/geozarr_vrt.py
+++ b/src/qgis_stac/geozarr_vrt.py
@@ -1,0 +1,288 @@
+"""Helpers for loading GeoZarr / Zarr v3 reflectance into QGIS via GDAL.
+
+This module intentionally stays conservative: it builds a simple single-resolution
+VRT (separate bands) and injects georeferencing from STAC projection metadata when
+available.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Sequence
+
+from osgeo import gdal, osr
+
+
+@dataclass(frozen=True)
+class GeoZarrVrtSpec:
+    reflectance_base_url: str
+    name: str
+    bands: tuple[str, ...] = ("b02", "b03", "b04", "b08")
+    base_resolution: str = "auto"  # r10m|r20m|r60m|auto
+    base_resolution_candidates: tuple[str, ...] = ("r10m", "r20m", "r60m")
+    resampling: str = "near"
+    vsi_prefix: str = "/vsicurl"
+    epsg: int | None = None
+    srs_wkt: str | None = None
+    bbox: tuple[float, float, float, float] | None = None
+    geotransform: tuple[float, float, float, float, float, float] | None = None
+
+
+def _inject_georeferencing(
+    vrt_path: str,
+    *,
+    epsg: int | None,
+    srs_wkt: str | None,
+    bbox: tuple[float, float, float, float] | None,
+    geotransform: tuple[float, float, float, float, float, float] | None,
+    shape: tuple[int, int] | None,
+) -> None:
+    if (not epsg and not srs_wkt) or (not bbox and not geotransform):
+        return
+
+    ds = gdal.Open(vrt_path)
+    if ds is None:
+        return
+
+    xsize = int(ds.RasterXSize or 0)
+    ysize = int(ds.RasterYSize or 0)
+    ds = None
+    if xsize <= 0 or ysize <= 0:
+        return
+
+    if geotransform is not None:
+        gt0, gt1, gt2, gt3, gt4, gt5 = geotransform
+        if gt1 == 0.0 and gt5 == 0.0:
+            return
+        gt_text = f"{gt0}, {gt1}, {gt2}, {gt3}, {gt4}, {gt5}"
+    else:
+        minx, miny, maxx, maxy = bbox  # type: ignore[misc]
+        px_w = (maxx - minx) / float(xsize)
+        px_h = (maxy - miny) / float(ysize)
+        if px_w == 0.0 or px_h == 0.0:
+            return
+        gt_text = f"{minx}, {px_w}, 0, {maxy}, 0, {-px_h}"
+
+    wkt = None
+    if srs_wkt and str(srs_wkt).strip():
+        wkt = str(srs_wkt).strip()
+    elif epsg:
+        sr = osr.SpatialReference()
+        sr.ImportFromEPSG(int(epsg))
+        wkt = sr.ExportToWkt()
+
+    if not wkt:
+        return
+
+    tree = ET.parse(vrt_path)
+    root = tree.getroot()
+
+    srs_el = root.find("SRS")
+    if srs_el is None:
+        srs_el = ET.Element("SRS")
+        root.insert(0, srs_el)
+    srs_el.text = wkt
+
+    gt_el = root.find("GeoTransform")
+    if gt_el is None:
+        gt_el = ET.Element("GeoTransform")
+        insert_at = 1 if root.find("SRS") is not None else 0
+        root.insert(insert_at, gt_el)
+
+    gt_el.text = gt_text
+
+    tree.write(vrt_path, encoding="utf-8", xml_declaration=True)
+
+
+_ZARR_MEDIA_TYPE_PREFIXES = (
+    "application/vnd+zarr",
+    "application/vnd.zarr",
+)
+
+
+def is_zarr_media_type(media_type: str | None) -> bool:
+    if not media_type:
+        return False
+    mt = media_type.strip().lower()
+    return any(prefix in mt for prefix in _ZARR_MEDIA_TYPE_PREFIXES)
+
+
+def derive_reflectance_base(href: str) -> str | None:
+    href = (href or "").strip()
+    if not href:
+        return None
+
+    href = href.rstrip("/")
+
+    if href.endswith("/measurements/reflectance"):
+        return href
+
+    if href.endswith("/measurements/reflectance/r10m"):
+        return href[:-5]
+
+    m = re.search(r"(/measurements/reflectance)(?:/r\d+m/[^/]+/zarr\.json)$", href)
+    if m:
+        return href[: m.end(1)]
+
+    return None
+
+
+def normalize_vsi_href(href: str, vsi_prefix: str = "/vsicurl") -> str:
+    href = (href or "").strip()
+    if not href:
+        return href
+
+    if href.startswith("/vsi"):
+        return href
+
+    if href.startswith("s3://"):
+        # s3://bucket/key -> /vsis3/bucket/key
+        return "/vsis3/" + href[len("s3://") :]
+
+    if href.startswith("http://") or href.startswith("https://"):
+        return f"{vsi_prefix.rstrip('/')}/{href}"
+
+    return href
+
+
+def _is_valid_resolution(res: str) -> bool:
+    return bool(re.match(r"^r\d+m$", (res or "").strip().lower()))
+
+
+def _build_vrt_for_resolution(
+    *,
+    ref_base: str,
+    resolution: str,
+    bands: Sequence[str],
+    out_vrt: str,
+    resampling: str,
+    vsi_prefix: str,
+) -> str:
+    sources: list[str] = []
+    for band in bands:
+        src_href = f"{ref_base.rstrip('/')}/{resolution}/{band}/zarr.json"
+        src = normalize_vsi_href(src_href, vsi_prefix=vsi_prefix)
+        try:
+            ds = gdal.Open(src)
+        except Exception:
+            ds = None
+        if ds is None:
+            continue
+        ds = None
+        sources.append(src)
+
+    if not sources:
+        raise RuntimeError(
+            f"No readable Zarr band sources for {resolution} under {ref_base}"
+        )
+
+    options = gdal.BuildVRTOptions(separate=True, resampleAlg=resampling)
+    vrt_ds = gdal.BuildVRT(out_vrt, sources, options=options)
+    if vrt_ds is None:
+        raise RuntimeError(f"Failed to build VRT for {resolution}")
+    vrt_ds = None
+
+    tree = ET.parse(out_vrt)
+    root = tree.getroot()
+    for idx, band_el in enumerate(root.findall("VRTRasterBand"), start=1):
+        if idx > len(bands):
+            break
+        desc_el = band_el.find("Description")
+        if desc_el is None:
+            desc_el = ET.Element("Description")
+            band_el.insert(0, desc_el)
+        desc_el.text = bands[idx - 1]
+    tree.write(out_vrt, encoding="utf-8", xml_declaration=True)
+
+    return out_vrt
+
+
+def build_multiscale_reflectance_vrt(spec: GeoZarrVrtSpec, out_dir: str) -> str:
+    """Build a simple single-resolution VRT for reflectance bands.
+
+    The function name is kept for backward compatibility with earlier iterations.
+    """
+    ref_base = spec.reflectance_base_url.strip()
+    ref_base = ref_base.replace("/vsicurl/", "").replace("/vsicurl", "")
+    ref_base = ref_base.rstrip("/")
+
+    if not ref_base.endswith("/measurements/reflectance"):
+        derived = derive_reflectance_base(ref_base)
+        if derived:
+            ref_base = derived
+
+    name = re.sub(r"[^A-Za-z0-9._-]+", "_", spec.name).strip("_") or "scene"
+    os.makedirs(out_dir, exist_ok=True)
+
+    bands = tuple(b.lower() for b in spec.bands)
+    for b in bands:
+        if not re.match(r"^b[a-z0-9]+$", b):
+            raise ValueError(f"Invalid band name: {b}")
+
+    base_res = spec.base_resolution.strip().lower()
+    if base_res != "auto" and not _is_valid_resolution(base_res):
+        raise ValueError(f"Invalid base_resolution: {spec.base_resolution}")
+
+    candidates = [
+        c.strip().lower() for c in spec.base_resolution_candidates if c.strip()
+    ]
+    candidates = [c for c in candidates if _is_valid_resolution(c)] or [
+        "r10m",
+        "r20m",
+        "r60m",
+    ]
+    if base_res != "auto":
+        candidates = [base_res]
+
+    last_err: Exception | None = None
+    for res in candidates:
+        out_vrt = os.path.join(out_dir, f"{name}_{res}.vrt")
+        try:
+            _build_vrt_for_resolution(
+                ref_base=ref_base,
+                resolution=res,
+                bands=bands,
+                out_vrt=out_vrt,
+                resampling=spec.resampling,
+                vsi_prefix=spec.vsi_prefix,
+            )
+            _inject_georeferencing(
+                out_vrt,
+                epsg=spec.epsg,
+                srs_wkt=spec.srs_wkt,
+                bbox=spec.bbox,
+                geotransform=spec.geotransform,
+                shape=None,
+            )
+            return out_vrt
+        except Exception as e:
+            last_err = e
+            continue
+
+    raise RuntimeError(f"Failed to build reflectance VRT for {ref_base}: {last_err}")
+
+
+def build_multiscale_reflectance_vrt_temp(spec: GeoZarrVrtSpec) -> str:
+    tmp_dir = tempfile.mkdtemp(prefix="qgis_stac_geozarr_")
+    try:
+        return build_multiscale_reflectance_vrt(spec, out_dir=tmp_dir)
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
+
+def build_multiscale_reflectance_vrt_cached(
+    spec: GeoZarrVrtSpec, cache_root: str
+) -> str:
+    """Compatibility wrapper.
+
+    The minimal implementation no longer maintains an on-disk cache; callers can
+    add caching later if needed.
+    """
+    _ = cache_root
+    return build_multiscale_reflectance_vrt_temp(spec)

--- a/src/qgis_stac/gui/asset_widget.py
+++ b/src/qgis_stac/gui/asset_widget.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    Asset item widget, used as a template for each item asset.
+Asset item widget, used as a template for each item asset.
 """
 
 import os
@@ -25,7 +25,7 @@ WidgetUi, _ = loadUiType(
 
 
 class AssetWidget(QtWidgets.QWidget, WidgetUi):
-    """ Widget that provide UI for asset details,
+    """Widget that provide UI for asset details,
     assets loading and downloading functionalities
     """
 
@@ -49,7 +49,7 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
         self.initialize_ui()
 
     def initialize_ui(self):
-        """ Populate UI inputs when loading the widget"""
+        """Populate UI inputs when loading the widget"""
 
         self.title_la.setText(self.asset.title)
         self.type_la.setText(self.asset.type)
@@ -63,53 +63,52 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
 
         if asset_load:
             self.load_box.setToolTip(
-                tr("Asset contains {} media type which "
-                   "cannot be loaded as a map layer in QGIS"
-                   ).format(self.asset.type)
+                tr(
+                    "Asset contains {} media type which "
+                    "cannot be loaded as a map layer in QGIS"
+                ).format(self.asset.type)
             )
 
     def asset_loadable(self):
-        """ Returns if asset can be added into QGIS"""
+        """Returns if asset can be added into QGIS"""
 
         layer_types = [
             AssetLayerType.COG.value,
             AssetLayerType.COPC.value,
             AssetLayerType.GEOTIFF.value,
             AssetLayerType.NETCDF.value,
+            AssetLayerType.ZARR.value,
         ]
 
         if self.asset.type is not None:
-            return self.asset.type in ''.join(layer_types)
+            asset_type = self.asset.type.lower()
+            return any(layer_type.lower() in asset_type for layer_type in layer_types)
         else:
             try:
-                request = QtNetwork.QNetworkRequest(
-                    QtCore.QUrl(self.asset.href)
-                )
-                response = QgsNetworkAccessManager().\
-                    instance().blockingGet(request)
+                request = QtNetwork.QNetworkRequest(QtCore.QUrl(self.asset.href))
+                response = QgsNetworkAccessManager().instance().blockingGet(request)
                 content_type = response.rawHeader(
-                    QtCore.QByteArray(
-                        'content-type'.encode()
-                    )
+                    QtCore.QByteArray("content-type".encode())
                 )
-                content_type = str(content_type, 'utf-8')
+                content_type = str(content_type, "utf-8")
 
                 for layer_type in layer_types:
-                    layer_type_values = layer_type.split(' ')
+                    layer_type_values = layer_type.split(" ")
                     for value in layer_type_values:
                         if value in content_type:
                             return True
 
             except Exception as e:
-                log(f"Problem fetching asset "
+                log(
+                    f"Problem fetching asset "
                     f"type from the asset url {self.asset.href},"
                     f" error {e}"
-                    )
+                )
 
             return False
 
     def asset_load_selected(self, state=None):
-        """ Emits the needed signal when an asset has been selected
+        """Emits the needed signal when an asset has been selected
         for loading.
         """
         if self.load_box.isChecked():
@@ -118,9 +117,9 @@ class AssetWidget(QtWidgets.QWidget, WidgetUi):
             self.load_deselected.emit()
 
     def asset_download_selected(self, state=None):
-        """ Emits the needed signal when an asset has been selected
-            for downloading.
-            """
+        """Emits the needed signal when an asset has been selected
+        for downloading.
+        """
         if self.download_box.isChecked():
             self.download_selected.emit()
         else:

--- a/src/qgis_stac/gui/assets_dialog.py
+++ b/src/qgis_stac/gui/assets_dialog.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 """
-    Assets dialog, shows all the available assets.
+Assets dialog, shows all the available assets.
 """
 
 import os
 import os.path
 
 from pathlib import Path
+from urllib.parse import quote
 from osgeo import ogr, gdal
 
 from functools import partial
@@ -29,31 +30,31 @@ from qgis.core import (
     QgsRasterLayer,
     QgsTask,
     QgsVectorLayer,
-
 )
 from ..lib import planetary_computer as pc
 
 from ..resources import *
 
-from ..api.models import (
-    AssetLayerType,
-    ApiCapability
-)
+from ..api.models import AssetLayerType, ApiCapability
 
 from ..definitions.constants import (
     GDAL_METADATA_NAME,
     GDAL_SUBDATASETS_KEY,
-    SAS_SUBSCRIPTION_VARIABLE
+    SAS_SUBSCRIPTION_VARIABLE,
 )
 
-from ..conf import (
-    Settings,
-    settings_manager
-)
+from ..conf import Settings, settings_manager
 
 from .asset_widget import AssetWidget
 
 from ..utils import log, tr
+
+from ..geozarr_vrt import (
+    GeoZarrVrtSpec,
+    build_multiscale_reflectance_vrt_temp,
+    derive_reflectance_base,
+    is_zarr_media_type,
+)
 
 DialogUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/item_assets_widget.ui")
@@ -61,15 +62,10 @@ DialogUi, _ = loadUiType(
 
 
 class AssetsDialog(QtWidgets.QDialog, DialogUi):
-    """ Dialog for adding and downloading STAC Item assets"""
+    """Dialog for adding and downloading STAC Item assets"""
 
-    def __init__(
-            self,
-            item,
-            parent,
-            main_widget
-    ):
-        """ Constructor
+    def __init__(self, item, parent, main_widget):
+        """Constructor
 
         :param item: Item object with assets that are to be shown.
         :type item: model.Item
@@ -86,7 +82,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         self.assets = item.assets
         self.parent = parent
         self.main_widget = main_widget
-        self.vis_url_string = '/vsicurl/'
+        self.vis_url_string = "/vsicurl/"
         self.download_result = {}
         self.load_assets = {}
         self.download_assets = {}
@@ -99,24 +95,15 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         self.layers = {}
 
     def prepare_assets(self):
-        """ Loads the dialog with the list of assets.
-        """
+        """Loads the dialog with the list of assets."""
 
         if len(self.assets) > 0:
-            self.title.setText(
-                tr("Item {}").
-                format(self.item.id)
-            )
+            self.title.setText(tr("Item {}").format(self.item.id))
             self.asset_count.setText(
-                tr("{} available asset(s)").
-                format(len(self.assets))
-
+                tr("{} available asset(s)").format(len(self.assets))
             )
         else:
-            self.title.setText(
-                tr("Item {} has no assets").
-                format(self.item.id)
-            )
+            self.title.setText(tr("Item {} has no assets").format(self.item.id))
 
         scroll_container = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout()
@@ -154,21 +141,16 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             layout.addWidget(asset_widget)
             layout.setAlignment(asset_widget, QtCore.Qt.AlignTop)
         vertical_spacer = QtWidgets.QSpacerItem(
-            20,
-            40,
-            QtWidgets.QSizePolicy.Minimum,
-            QtWidgets.QSizePolicy.Expanding
+            20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding
         )
         layout.addItem(vertical_spacer)
         scroll_container.setLayout(layout)
-        self.scroll_area.setHorizontalScrollBarPolicy(
-            QtCore.Qt.ScrollBarAlwaysOff
-        )
+        self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area.setWidget(scroll_container)
 
     def load_asset_selected(self, asset):
-        """ Handles operations after an asset load box has been selected.
+        """Handles operations after an asset load box has been selected.
 
         :param asset: STAC item asset
         :type asset: ResourceAsset
@@ -181,117 +163,116 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         self.load_btn.setEnabled(True)
 
     def download_asset_selected(self, asset):
-        """ Handles operations after an asset download box has been selected.
+        """Handles operations after an asset download box has been selected.
 
         :param asset: STAC item asset
         :type asset: ResourceAsset
         """
         self.download_assets[asset.title] = asset
         self.download_btn.setText(
-            f"Download the selected assets "
-            f"({len(self.download_assets.items())})"
+            f"Download the selected assets " f"({len(self.download_assets.items())})"
         )
         self.download_btn.setEnabled(True)
 
     def load_asset_deselected(self, asset):
-        """ Handles operations after an asset load box has been deselected.
+        """Handles operations after an asset load box has been deselected.
 
         :param asset: STAC item asset
         :type asset: ResourceAsset
         """
 
-        self.load_assets.pop(asset.title) \
-            if self.load_assets.get(asset.title, None) else None
+        (
+            self.load_assets.pop(asset.title)
+            if self.load_assets.get(asset.title, None)
+            else None
+        )
 
-        self.load_btn.setText(
-            f"Add selected assets as layers "
-            f"({len(self.load_assets.items())})"
-        ) if len(self.load_assets.items()) > 0 else \
+        (
             self.load_btn.setText(
-                "Add assets as layers"
+                f"Add selected assets as layers " f"({len(self.load_assets.items())})"
             )
+            if len(self.load_assets.items()) > 0
+            else self.load_btn.setText("Add assets as layers")
+        )
 
         self.load_btn.setEnabled(len(self.load_assets.items()) > 0)
 
     def download_asset_deselected(self, asset):
-        """ Handles operations after an asset download box has been deselected.
+        """Handles operations after an asset download box has been deselected.
 
         :param asset: STAC item asset
         :type asset: ResourceAsset
         """
 
-        self.download_assets.pop(asset.title) \
-            if self.download_assets.get(asset.title) else None
-
-        self.download_btn.setText(
-            f"Download the selected assets "
-            f"({len(self.download_assets.items())})"
-        ) if len(self.download_assets.items()) > 0 else \
-            self.download_btn.setText(
-                "Download the selected assets"
-            )
-
-        self.download_btn.setEnabled(
-            len(self.download_assets.items()) > 0
+        (
+            self.download_assets.pop(asset.title)
+            if self.download_assets.get(asset.title)
+            else None
         )
 
+        (
+            self.download_btn.setText(
+                f"Download the selected assets "
+                f"({len(self.download_assets.items())})"
+            )
+            if len(self.download_assets.items()) > 0
+            else self.download_btn.setText("Download the selected assets")
+        )
+
+        self.download_btn.setEnabled(len(self.download_assets.items()) > 0)
+
     def load_btn_clicked(self):
-        """ Runs logic after the asset load button has been clicked.
-        """
+        """Runs logic after the asset load button has been clicked."""
         for key, asset in self.load_assets.items():
             try:
                 load_task = QgsTask.fromFunction(
-                    'Load asset function',
-                    self.load_asset(asset)
+                    "Load asset function", self.load_asset(asset)
                 )
                 QgsApplication.taskManager().addTask(load_task)
             except Exception as err:
-                log(tr("An error occurred when running task for "
-                       "loading an asset, error message \"{}\" ".format(err))
+                log(
+                    tr(
+                        "An error occurred when running task for "
+                        'loading an asset, error message "{}" '.format(err)
                     )
+                )
 
     def download_btn_clicked(self):
-        """ Runs logic after the asset download button has been clicked.
-        """
+        """Runs logic after the asset download button has been clicked."""
         auto_asset_loading = settings_manager.get_value(
-            Settings.AUTO_ASSET_LOADING,
-            False,
-            setting_type=bool
+            Settings.AUTO_ASSET_LOADING, False, setting_type=bool
         )
 
         for key, asset in self.download_assets.items():
             try:
                 download_task = QgsTask.fromFunction(
-                    'Download asset function',
-                    self.download_asset(asset, auto_asset_loading)
+                    "Download asset function",
+                    self.download_asset(asset, auto_asset_loading),
                 )
                 QgsApplication.taskManager().addTask(download_task)
 
             except Exception as err:
                 self.update_inputs(True)
-                log(tr("An error occured when running task for"
-                       " downloading asset {}, error message \"{}\" ").format(
-                    asset.title,
-                    str(err))
+                log(
+                    tr(
+                        "An error occured when running task for"
+                        ' downloading asset {}, error message "{}" '
+                    ).format(asset.title, str(err))
                 )
 
     def update_inputs(self, enabled):
-        """ Updates the inputs widgets state in the main search item widget.
+        """Updates the inputs widgets state in the main search item widget.
 
         :param enabled: Whether to enable the inputs or disable them.
         :type enabled: bool
         """
         self.scroll_area.setEnabled(enabled)
         self.parent.update_inputs(enabled)
-        self.load_btn.setEnabled(
-            enabled and len(self.load_assets.items()) > 0
-        )
-        self.download_btn.setEnabled(
-            enabled and len(self.download_assets.items()) > 0
-        )
+        self.load_btn.setEnabled(enabled and len(self.load_assets.items()) > 0)
+        self.download_btn.setEnabled(enabled and len(self.download_assets.items()) > 0)
 
     def download_asset(self, asset, load_asset=False):
-        """ Downloads the passed asset into directory defined in the plugin settings.
+        """Downloads the passed asset into directory defined in the plugin settings.
 
         :param asset: Item asset
         :type asset: models.ResourceAsset
@@ -300,11 +281,10 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         :type load_asset: bool
         """
         self.update_inputs(False)
-        download_folder = settings_manager.get_value(
-            Settings.DOWNLOAD_FOLDER
+        download_folder = settings_manager.get_value(Settings.DOWNLOAD_FOLDER)
+        item_folder = (
+            os.path.join(download_folder, self.item.id) if download_folder else None
         )
-        item_folder = os.path.join(download_folder, self.item.id) \
-            if download_folder else None
         feedback = QgsProcessingFeedback()
         try:
             if item_folder:
@@ -314,29 +294,29 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         except FileNotFoundError as fn:
             self.update_inputs(True)
             self.main_widget.show_message(
-                tr("Folder {} is not found").format(download_folder),
-                Qgis.Critical
+                tr("Folder {} is not found").format(download_folder), Qgis.Critical
             )
             return
         except PermissionError as pe:
             self.update_inputs(True)
             self.main_widget.show_message(
-                tr("Permission error writing in download folder"),
-                Qgis.Critical
+                tr("Permission error writing in download folder"), Qgis.Critical
             )
             return
 
         url = self.sign_asset_href(asset.href)
         extension = Path(asset.href).suffix
-        extension_suffix = extension.split('?')[0] if extension else ""
+        extension_suffix = extension.split("?")[0] if extension else ""
         title = f"{asset.title}{extension_suffix}"
 
         title = self.clean_filename(title)
 
-        output = os.path.join(
-            item_folder, title
-        ) if item_folder else QgsProcessing.TEMPORARY_OUTPUT
-        params = {'URL': url, 'OUTPUT': output}
+        output = (
+            os.path.join(item_folder, title)
+            if item_folder
+            else QgsProcessing.TEMPORARY_OUTPUT
+        )
+        params = {"URL": url, "OUTPUT": output}
 
         self.download_result["file"] = output
 
@@ -348,12 +328,10 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         ]
         try:
             self.main_widget.show_message(
-                tr("Download for file {} to {} has started."
-                   ).format(
-                    title,
-                    item_folder
+                tr("Download for file {} to {} has started.").format(
+                    title, item_folder
                 ),
-                level=Qgis.Info
+                level=Qgis.Info,
             )
             self.main_widget.show_progress(
                 f"Downloading {url}",
@@ -361,24 +339,21 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
                 maximum=100,
             )
 
-            feedback.progressChanged.connect(
-                self.main_widget.update_progress_bar
-            )
+            feedback.progressChanged.connect(self.main_widget.update_progress_bar)
             feedback.progressChanged.connect(self.download_progress)
 
-            results = processing.run(
-                "qgis:filedownloader",
-                params,
-                feedback=feedback
-            )
+            results = processing.run("qgis:filedownloader", params, feedback=feedback)
 
             # After asset download has finished, load the asset
             # if it can be loaded as a QGIS map layer.
-            if results and load_asset and asset.type in ''.join(layer_types):
+            if results and load_asset and asset.type in "".join(layer_types):
                 asset.href = self.download_result["file"]
                 asset.name = title
-                asset.type = AssetLayerType.GEOTIFF.value \
-                    if AssetLayerType.COG.value in asset.type else asset.type
+                asset.type = (
+                    AssetLayerType.GEOTIFF.value
+                    if AssetLayerType.COG.value in asset.type
+                    else asset.type
+                )
                 self.load_asset(asset)
 
         except Exception as e:
@@ -388,7 +363,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             )
 
     def sign_asset_href(self, asset_href):
-        """ Signs the SAS based asset href.
+        """Signs the SAS based asset href.
 
         :param asset_href: Asset resource href
         :type asset_href: str
@@ -402,10 +377,12 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         sas_key = os.getenv(SAS_SUBSCRIPTION_VARIABLE)
         connection = settings_manager.get_current_connection()
 
-        if connection and \
-                connection.capability == ApiCapability.SUPPORT_SAS_TOKEN:
-            sas_key = connection.sas_subscription_key \
-                if connection.sas_subscription_key else sas_key
+        if connection and connection.capability == ApiCapability.SUPPORT_SAS_TOKEN:
+            sas_key = (
+                connection.sas_subscription_key
+                if connection.sas_subscription_key
+                else sas_key
+            )
 
             pc.set_subscription_key(sas_key) if sas_key else None
 
@@ -424,15 +401,14 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         if value == 100:
             self.update_inputs(True)
             self.main_widget.show_message(
-                tr("Download for file {} has finished."
-                   ).format(
+                tr("Download for file {} has finished.").format(
                     self.download_result["file"]
                 ),
-                level=Qgis.Info
+                level=Qgis.Info,
             )
 
     def clean_filename(self, filename):
-        """ Creates a safe filename by removing operating system
+        """Creates a safe filename by removing operating system
         invalid filename characters.
 
         :param filename: File name
@@ -445,49 +421,89 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
 
         for character in characters:
             if character in filename:
-                filename = filename.replace(character, '_')
+                filename = filename.replace(character, "_")
 
         return filename
 
     def load_asset(self, asset):
-        """ Loads asset into QGIS.
+        """Loads asset into QGIS.
             Checks if the asset type is a loadable layer inside QGIS.
 
         :param asset: Item asset
         :type asset: models.ResourceAsset
         """
 
-        asset_type = asset.type
-        raster_types = ','.join([
-            AssetLayerType.COG.value,
-            AssetLayerType.GEOTIFF.value,
-            AssetLayerType.NETCDF.value
-        ])
-        vector_types = ','.join([
-            AssetLayerType.GEOJSON.value,
-            AssetLayerType.GEOPACKAGE.value
-        ])
-        point_cloud_types = ','.join([
-            AssetLayerType.COPC.value,
-        ])
+        asset_type = asset.type or ""
+        raster_types = ",".join(
+            [
+                AssetLayerType.COG.value,
+                AssetLayerType.GEOTIFF.value,
+                AssetLayerType.NETCDF.value,
+            ]
+        )
+        vector_types = ",".join(
+            [AssetLayerType.GEOJSON.value, AssetLayerType.GEOPACKAGE.value]
+        )
+        point_cloud_types = ",".join(
+            [
+                AssetLayerType.COPC.value,
+            ]
+        )
         current_asset_href = asset.href
         asset.href = self.sign_asset_href(asset.href)
 
-        if asset_type in raster_types:
+        if asset_type in raster_types or is_zarr_media_type(asset_type):
             layer_type = QgsMapLayer.RasterLayer
         elif asset_type in vector_types:
             layer_type = QgsMapLayer.VectorLayer
         elif asset_type in point_cloud_types:
             layer_type = QgsMapLayer.PointCloudLayer
 
-        if asset_type in ''.join(
-                [AssetLayerType.COG.value]
-        ) and \
-                asset_type != AssetLayerType.GEOTIFF.value:
-            asset_href = f"{self.vis_url_string}" \
-                         f"{asset.href}"
-        elif asset_type in ''.join([
-            AssetLayerType.NETCDF.value]):
+        if (
+            asset_type in "".join([AssetLayerType.COG.value])
+            and asset_type != AssetLayerType.GEOTIFF.value
+        ):
+            asset_href = f"{self.vis_url_string}" f"{asset.href}"
+        elif is_zarr_media_type(asset_type):
+            asset_name = asset.name or asset.title
+            ref_base = derive_reflectance_base(asset.href) or asset.href
+
+            xyz_url = self._find_item_link_href("xyz")
+            if xyz_url and ("reflectance" in (asset.roles or [])):
+                try:
+                    encoded_url = quote(str(xyz_url), safe=":/?{}%")
+                    xyz_uri = f"type=xyz&url={encoded_url}"
+                    preview_layer = QgsRasterLayer(
+                        xyz_uri, f"{asset_name} (preview)", "wms"
+                    )
+                    if preview_layer.isValid():
+                        QgsProject.instance().addMapLayer(preview_layer)
+                        self.main_widget.show_message(
+                            tr("Sucessfully added asset {} as a map layer ").format(
+                                asset_name
+                            ),
+                            level=Qgis.Info,
+                        )
+                except Exception:
+                    pass
+
+                epsg, gt = self._best_proj_epsg_geotransform()
+                self.update_inputs(False)
+                self.add_layer_task(
+                    ref_base,
+                    f"{asset_name} (data)",
+                    layer_type,
+                    geozarr=True,
+                    hide_on_add=True,
+                    geozarr_epsg=epsg,
+                    geozarr_geotransform=gt,
+                )
+                return
+
+            self.update_inputs(False)
+            self.add_layer_task(ref_base, asset_name, layer_type, geozarr=True)
+            return
+        elif asset_type in "".join([AssetLayerType.NETCDF.value]):
             # For NETCDF assets type we need to download the intended asset first,
             # then we read from the downloaded file and use all the available NETCDF
             # variables on the file to load the layer.
@@ -500,9 +516,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
                     gdal.UseExceptions()
                     open_file = gdal.Open(asset.href)
                     if open_file is not None:
-                        file_metadata = open_file.GetMetadata(
-                            GDAL_SUBDATASETS_KEY
-                        )
+                        file_metadata = open_file.GetMetadata(GDAL_SUBDATASETS_KEY)
                         file_uris = []
                         for key, value in file_metadata.items():
                             if GDAL_METADATA_NAME in key:
@@ -512,8 +526,9 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
                 except RuntimeError as err:
                     asset_href = asset.href
                     log(
-                        tr("Runtime error when adding a NETCDF asset,"
-                           " {}").format(str(err))
+                        tr("Runtime error when adding a NETCDF asset," " {}").format(
+                            str(err)
+                        )
                     )
             else:
                 asset.href = current_asset_href
@@ -532,8 +547,17 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         else:
             self.add_layer_task(asset_href, asset_name, layer_type)
 
-    def add_layer_task(self, asset_href, asset_name, layer_type):
-        """ Helps in spinning up a QGIS task for loading the required asset
+    def add_layer_task(
+        self,
+        asset_href,
+        asset_name,
+        layer_type,
+        geozarr=False,
+        hide_on_add=False,
+        geozarr_epsg=None,
+        geozarr_geotransform=None,
+    ):
+        """Helps in spinning up a QGIS task for loading the required asset
 
         :param asset_href: URI of the asset
         :type asset_href: str
@@ -548,14 +572,14 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         layer_loader = LayerLoader(
             asset_href,
             asset_name,
-            layer_type
+            layer_type,
+            geozarr=geozarr,
+            hide_on_add=hide_on_add,
+            geozarr_epsg=geozarr_epsg,
+            geozarr_geotransform=geozarr_geotransform,
         )
 
-        add_layer_partial = partial(
-            self.add_layer,
-            asset_name,
-            layer_loader
-        )
+        add_layer_partial = partial(self.add_layer, asset_name, layer_loader)
 
         # Using signal approach to detect the results of the layer loader
         # task as the callback function approach doesn't make the task
@@ -567,7 +591,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         QgsApplication.taskManager().addTask(layer_loader)
 
         self.main_widget.show_progress(
-            f"Adding asset \"{asset_name}\" into QGIS",
+            f'Adding asset "{asset_name}" into QGIS',
             minimum=0,
             maximum=100,
         )
@@ -575,7 +599,7 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
         log(tr("Started adding asset into QGIS"))
 
     def add_layer(self, asset_name, layer_loader):
-        """ Adds layer into the current QGIS project.
+        """Adds layer into the current QGIS project.
             For the layer to be added successfully, the task for loading
             layer need to exist and the corresponding layer need to be
             available.
@@ -591,9 +615,12 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
             layer = layer_loader.layer
             QgsProject.instance().addMapLayer(layer)
 
-            message = tr(
-                "Sucessfully added asset {} as a map layer "
-            ).format(
+            if getattr(layer_loader, "hide_on_add", False):
+                node = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
+                if node is not None:
+                    node.setItemVisibilityChecked(False)
+
+            message = tr("Sucessfully added asset {} as a map layer ").format(
                 asset_name
             )
             level = Qgis.Info
@@ -613,63 +640,132 @@ class AssetsDialog(QtWidgets.QDialog, DialogUi):
 
         self.update_inputs(True)
         log(message)
-        self.main_widget.show_message(
-            message,
-            level=level
-        )
+        self.main_widget.show_message(message, level=level)
 
     def layer_loader_terminated(self):
-        """ Shows message to user when layer loading task has been terminated"""
+        """Shows message to user when layer loading task has been terminated"""
         message = tr("QGIS background task for loading assets was terminated.")
         self.update_inputs(True)
         log(message)
-        self.main_widget.show_message(
-            message,
-            level=Qgis.Critical
-        )
+        self.main_widget.show_message(message, level=Qgis.Critical)
 
     def handle_layer_error(self, message):
-        """ Handles the error message from the layer loading task
+        """Handles the error message from the layer loading task
 
         :param message: The error message
         :type message: str
         """
         self.update_inputs(True)
         log(message)
-        self.main_widget.show_message(
-            message
-        )
+        self.main_widget.show_message(message)
+
+    def _find_item_link_href(self, rel: str):
+        wanted = (rel or "").lower()
+        item_links = getattr(self.item, "links", None) or []
+        for link in item_links:
+            try:
+                if isinstance(link, dict):
+                    link_rel = (link.get("rel") or "").lower()
+                    link_href = link.get("href")
+                else:
+                    link_rel = (getattr(link, "rel", None) or "").lower()
+                    link_href = getattr(link, "href", None)
+
+                if link_rel == wanted and link_href:
+                    return str(link_href)
+            except Exception:
+                continue
+        return None
+
+    def _best_proj_epsg_geotransform(self):
+        stac_obj = getattr(self.item, "stac_object", None)
+        props = getattr(stac_obj, "properties", None)
+        if not isinstance(props, dict):
+            return None, None
+
+        epsg = props.get("proj:epsg")
+        proj_code = props.get("proj:code")
+
+        try:
+            epsg_i = int(epsg) if epsg is not None else None
+        except Exception:
+            epsg_i = None
+
+        if epsg_i is None and isinstance(proj_code, str):
+            code = proj_code.strip()
+            if code.upper().startswith("EPSG:"):
+                try:
+                    epsg_i = int(code.split(":", 1)[1])
+                except Exception:
+                    epsg_i = None
+
+        transform = props.get("proj:transform")
+        if epsg_i and isinstance(transform, (list, tuple)) and len(transform) == 6:
+            try:
+                gt = (
+                    float(transform[0]),
+                    float(transform[1]),
+                    float(transform[2]),
+                    float(transform[3]),
+                    float(transform[4]),
+                    float(transform[5]),
+                )
+                return int(epsg_i), gt
+            except Exception:
+                return int(epsg_i), None
+
+        return int(epsg_i) if epsg_i else None, None
 
 
 class LayerLoader(QgsTask):
-    """ Prepares and loads items assets inside QGIS as layers."""
+    """Prepares and loads items assets inside QGIS as layers."""
 
     def __init__(
-            self,
-            layer_uri,
-            layer_name,
-            layer_type
+        self,
+        layer_uri,
+        layer_name,
+        layer_type,
+        geozarr=False,
+        hide_on_add=False,
+        geozarr_epsg=None,
+        geozarr_geotransform=None,
     ):
 
         super().__init__()
         self.layer_uri = layer_uri
         self.layer_name = layer_name
         self.layer_type = layer_type
+        self.geozarr = geozarr
+        self.hide_on_add = hide_on_add
+        self.geozarr_epsg = geozarr_epsg
+        self.geozarr_geotransform = geozarr_geotransform
         self.error = None
         self.layer = None
         self.layers = []
 
     def run(self):
-        """ Operates the main layers loading logic
-        """
-        log(
-            tr("Fetching layers in a background task.")
-        )
+        """Operates the main layers loading logic"""
+        log(tr("Fetching layers in a background task."))
         if self.layer_type is QgsMapLayer.RasterLayer:
-            self.layer = QgsRasterLayer(
-                self.layer_uri,
-                self.layer_name
-            )
+            if self.geozarr:
+                try:
+                    spec = GeoZarrVrtSpec(
+                        reflectance_base_url=str(self.layer_uri),
+                        name=str(self.layer_name),
+                        vsi_prefix="/vsicurl",
+                        epsg=self.geozarr_epsg,
+                        srs_wkt=None,
+                        bbox=None,
+                        geotransform=self.geozarr_geotransform,
+                    )
+                    self.layer_uri = build_multiscale_reflectance_vrt_temp(spec)
+                except Exception as err:
+                    self.error = tr("Failed to build/read VRT for GeoZarr: {}").format(
+                        str(err)
+                    )
+                    log(self.error)
+                    return False
+            self.layer = QgsRasterLayer(self.layer_uri, self.layer_name)
             return self.layer.isValid()
         elif self.layer_type is QgsMapLayer.VectorLayer:
             extension = Path(self.layer_uri).suffix
@@ -677,9 +773,7 @@ class LayerLoader(QgsTask):
 
             if extension is not ".gpkg":
                 self.layer = QgsVectorLayer(
-                    self.layer_uri,
-                    self.layer_name,
-                    AssetLayerType.VECTOR.value
+                    self.layer_uri, self.layer_name, AssetLayerType.VECTOR.value
                 )
                 result = self.layer.isValid()
             else:
@@ -689,7 +783,7 @@ class LayerLoader(QgsTask):
                     layer = QgsVectorLayer(
                         f"{gpkg_connection}|layername={layer_item.GetName()}",
                         layer_item.GetName(),
-                        AssetLayerType.VECTOR.value
+                        AssetLayerType.VECTOR.value,
                     )
                     self.layers.append(layer.clone())
                     # If any layer from the geopackage is valid, load it.
@@ -698,11 +792,7 @@ class LayerLoader(QgsTask):
                         result = True
             return result
         elif self.layer_type is QgsMapLayer.PointCloudLayer:
-            self.layer = QgsPointCloudLayer(
-                self.layer_uri,
-                self.layer_name,
-                'copc'
-            )
+            self.layer = QgsPointCloudLayer(self.layer_uri, self.layer_name, "copc")
             return self.layer.isValid()
         else:
             raise NotImplementedError
@@ -710,17 +800,14 @@ class LayerLoader(QgsTask):
         return False
 
     def finished(self, result: bool):
-        """ Calls the handler responsible for adding the
+        """Calls the handler responsible for adding the
          layer into QGIS project.
 
         :param result: Whether the run() operation finished successfully
         :type result: bool
         """
         if result and self.layer:
-            log(
-                f"Fetched layer with URI "
-                f"{self.layer_uri} "
-            )
+            log(f"Fetched layer with URI " f"{self.layer_uri} ")
             # Due to the way QGIS is handling layers sharing between tasks and
             # the main thread, sending the layer to the main thread
             # without cloning it can lead to unpredicted crashes,
@@ -728,14 +815,12 @@ class LayerLoader(QgsTask):
             # be used in the main thread.
             self.layer = self.layer.clone()
         else:
-            provider_error = tr("error {}").format(
-                self.layer.dataProvider().error()
-            ) if self.layer and self.layer.dataProvider() else None
+            provider_error = (
+                tr("error {}").format(self.layer.dataProvider().error())
+                if self.layer and self.layer.dataProvider()
+                else None
+            )
             self.error = tr(
-                f"Couldn't load layer "
-                f"{self.layer_uri},"
-                f"{provider_error}"
+                f"Couldn't load layer " f"{self.layer_uri}," f"{provider_error}"
             )
-            log(
-                self.error
-            )
+            log(self.error)


### PR DESCRIPTION
## Why
STAC catalogs typically distribute satellite raster data as Cloud Optimized GeoTIFF (COG) assets, which GIS software such as QGIS can stream efficiently.

Within EOPF, there is ongoing progress toward a more cloud-native distribution using GeoZarr / Zarr v3. However, most GIS tooling does not (yet) support this format well in practice because it is new, and the data is chunked into many (often sparsely accessed) blobs, which changes access patterns and can trigger a large number of small remote reads.

## Summary
This PR adds experimental support for Zarr v3 / GeoZarr reflectance assets so they can be visualized in QGIS quickly (XYZ preview) and inspected for values (GDAL VRT-backed raster "data" layer). The aim for now is to gather feedback for further development. See screen recording for a quick demo that loads [a stac item](https://api.explorer.eopf.copernicus.eu/browser/external/api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a/items/S2B_MSIL2A_20251218T110359_N0511_R094_T32VMJ_20251218T115223) and visualizes a preview of the data + raster pixel values (the preview/xyz layer is at the bottom and the "data" layer at the top). 

[DEMO screen recording](https://github.com/user-attachments/assets/d60b7823-1307-4809-903d-5d41cc723ce4)

## User-facing behavior
- Zarr media types are treated as loadable raster assets.
- When adding a reflectance Zarr asset:
  - If the STAC item includes an `xyz` link and the asset roles include `reflectance`, the plugin adds a fast XYZ preview layer (`(preview)`), then adds a separate raster data layer (`(data)`) built from a GDAL VRT and hides it by default.
  - Otherwise, the plugin adds a single raster layer backed by a generated VRT.

## Implementation details
- Dependency bootstrap: force the plugin’s vendored `lib/` to load first (so QGIS’ bundled packages don’t override it).
- Zarr detection: recognize Zarr/GeoZarr media types (e.g. `application/vnd+zarr`) and treat them as raster assets.
- GeoZarr → VRT: build a temporary GDAL VRT that points at band `zarr.json` endpoints.
- Georeferencing: if projection metadata is present on the item, write it into the VRT.
  - Uses `proj:epsg` / `proj:code` + a 6-value `proj:transform` (GDAL GeoTransform).
- Layer visibility: supports adding the VRT-backed “data” layer hidden by default when a “preview” layer is also added.
- TODO: fix QGIS warnings on sharding (`WARNING    Surface Reflectance (data) : Sharded chunk range out of bounds`)

## Testing notes
- Manual: in QGIS, add an item with a reflectance Zarr asset and an `xyz` link.
  - Local install (run this PR version in QGIS):
    1. Close QGIS.
    2. Find your QGIS profile plugin folder:
       - macOS (default profile): `~/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/qgis_stac`
       - Linux (default profile): `~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/qgis_stac`
       - Windows (default profile): `%APPDATA%\QGIS\QGIS3\profiles\default\python\plugins\qgis_stac`
    3. Back up the installed plugin folder.
    4. Overlay this repo’s code from `qgis-stac-plugin/src/qgis_stac` onto the installed `qgis_stac` folder, preserving `metadata.txt`.

       Example (macOS/Linux) using `rsync`:
       ```bash
       PLUGIN_BASE="$HOME/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins"
       DEST="$PLUGIN_BASE/qgis_stac"
       SRC="/path/to/qgis-stac-plugin/src/qgis_stac"
       cp -a "$DEST" "$DEST.bak-$(date +%Y%m%d-%H%M%S)"
       rsync -a --delete \
         --exclude "metadata.txt" \
         --exclude "icon.png" \
         --exclude "resources.py" \
         "$SRC/" "$DEST/"
       ```

    5. Start QGIS and enable/reload the plugin.
  - Verify `(preview)` XYZ layer is added quickly.
  - Verify `(data)` raster layer is added (hidden) and can be toggled on for Identify/value inspection.
